### PR TITLE
Feature/f32 precision

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.8
+  python: python3
 
 repos:
 -   repo: https://github.com/psf/black

--- a/constraints.txt
+++ b/constraints.txt
@@ -20,11 +20,8 @@ asttokens==2.0.5
     # via
     #   devtools
     #   stack-data
-astunparse==1.6.3 ; python_version < "3.9"
-    # via
-    #   dace
-    #   gt4py
-    #   gt4py (external/gt4py/setup.cfg)
+astunparse==1.6.3
+    # via dace
 async-timeout==3.0.1
     # via aiohttp
 attrs==22.1.0
@@ -90,7 +87,7 @@ cytoolz==0.11.2
     # via
     #   gt4py
     #   gt4py (external/gt4py/setup.cfg)
-dace==0.14
+dace==0.14.1
     # via
     #   -r requirements_dev.txt
     #   pace-dsl
@@ -604,9 +601,7 @@ zarr==2.9.2
     #   pace-driver
     #   pace-driver (driver/setup.py)
 zipp==3.8.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,3 +1,14 @@
 ========
 Overview
 ========
+
+Execution
+---------
+
+A few environment variable change the behavior of the model:
+- FV3_DACEMODE=Python[Build|BuildAndRun|Run] controls the full program optimizer behavior
+  - Python: default, use stencil only, no full program optmization
+  - Build: will build the program then exit. This _build no matter what_. (backend must be `dace:gpu` or `dace:cpu`)
+  - BuildAndRun: same as above but after build the program will keep executing (backend must be `dace:gpu` or `dace:cpu`)
+  - Run: load pre-compiled program and execute, fail if the .so is not present (_no hashs check!_) (backend must be `dace:gpu` or `dace:cpu`)
+- PACE_FLOAT_PRECISION=64 control the floating point precision throughout the program.

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -21,7 +21,7 @@ from pace.driver.safety_checks import SafetyChecker
 from pace.dsl.dace.dace_config import DaceConfig
 from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.stencil_config import CompilationConfig, RunMode
-from pace.dsl.typing import Float
+from pace.dsl.typing import Float, global_set_floating_point_precision
 
 # TODO: move update_atmos_state into pace.driver
 from pace.stencils import update_atmos_state
@@ -92,6 +92,7 @@ class DriverConfig:
     nz: int
     layout: Tuple[int, int]
     dt_atmos: float
+    floating_point_precision_in_bit: int = 64
     grid_config: GridInitializerSelector = dataclasses.field(
         default_factory=lambda: GridInitializerSelector(
             type="generated", config=GeneratedGridConfig()
@@ -384,6 +385,7 @@ class Driver:
         """
         logger.info("initializing driver")
         self.config: DriverConfig = config
+        global_set_floating_point_precision(config.floating_point_precision_in_bit)
         self.time = self.config.start_time
         self.comm_config = config.comm_config
         global_comm = config.comm_config.get_comm()

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -21,6 +21,7 @@ from pace.driver.safety_checks import SafetyChecker
 from pace.dsl.dace.dace_config import DaceConfig
 from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.stencil_config import CompilationConfig, RunMode
+from pace.dsl.typing import Float
 
 # TODO: move update_atmos_state into pace.driver
 from pace.stencils import update_atmos_state
@@ -607,7 +608,7 @@ class Driver:
         self,
         steps_count: int,
         timer: pace.util.Timer,
-        dt: float,
+        dt: Float,
     ):
         """Start of code path where performance is critical.
 
@@ -626,17 +627,17 @@ class Driver:
                         dycore_state=self.state.dycore_state,
                         physics_state=self.state.physics_state,
                         tendency_state=self.state.tendency_state,
-                        timestep=float(dt),
+                        timestep=dt,
                     )
                     if not self.config.dycore_only:
-                        self.physics(self.state.physics_state, timestep=float(dt))
+                        self.physics(self.state.physics_state, timestep=dt)
                     self.end_of_step_update(
                         dycore_state=self.state.dycore_state,
                         phy_state=self.state.physics_state,
                         u_dt=self.state.tendency_state.u_dt,
                         v_dt=self.state.tendency_state.v_dt,
                         pt_dt=self.state.tendency_state.pt_dt,
-                        dt=float(dt),
+                        dt=dt,
                     )
             self._end_of_step_actions(step)
 
@@ -649,7 +650,7 @@ class Driver:
             self._critical_path_step_all(
                 steps_count=self.config.n_timesteps(),
                 timer=self.performance_collector.timestep_timer,
-                dt=self.config.timestep.total_seconds(),
+                dt=Float(self.config.timestep.total_seconds()),
             )
             PerformanceCollector.stop_cuda_profiler()
             self.profiler.dump_stats(

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -675,7 +675,7 @@ class Driver:
         )
         if (
             self.comm.Get_size()
-            >= self.config.performance_config.json_all_rank_threshold
+            <= self.config.performance_config.json_all_rank_threshold
         ):
             self._write_performance_json_output()
         self.diagnostics.store_grid(

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -1,6 +1,5 @@
 import dataclasses
 import functools
-import logging
 import warnings
 from datetime import datetime, timedelta
 from math import floor
@@ -26,6 +25,7 @@ from pace.dsl.typing import Float
 # TODO: move update_atmos_state into pace.driver
 from pace.stencils import update_atmos_state
 from pace.util.communicator import CubedSphereCommunicator
+from pace.util.logging import pace_log
 
 from . import diagnostics
 from .comm import CreatesCommSelector
@@ -40,8 +40,6 @@ try:
     import cupy as cp
 except ImportError:
     cp = None
-
-logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
@@ -382,7 +380,7 @@ class Driver:
             config: driver configuration
             comm: communication object behaving like mpi4py.Comm
         """
-        logger.info("initializing driver")
+        pace_log.info("initializing driver")
         self.config: DriverConfig = config
         self.time = self.config.start_time
         self.comm_config = config.comm_config
@@ -452,13 +450,13 @@ class Driver:
                 communicator=communicator,
                 stencil_compare_comm=stencil_compare_comm,
             )
-            logger.info("setting up grid started")
+            pace_log.info("setting up grid started")
             (damping_coefficients, driver_grid_data, grid_data,) = self.config.get_grid(
                 quantity_factory=self.quantity_factory,
                 communicator=communicator,
             )
-            logger.info("setting up grid done")
-            logger.info("setting up state started")
+            pace_log.info("setting up grid done")
+            pace_log.info("setting up state started")
             self.state = self.config.get_driver_state(
                 quantity_factory=self.quantity_factory,
                 communicator=communicator,
@@ -466,10 +464,10 @@ class Driver:
                 driver_grid_data=driver_grid_data,
                 grid_data=grid_data,
             )
-            logger.info("setting up state done")
+            pace_log.info("setting up state done")
 
             self._start_time = self.config.initialization.start_time
-            logger.info("setting up dycore object started")
+            pace_log.info("setting up dycore object started")
             self.dycore = fv3core.DynamicalCore(
                 comm=communicator,
                 grid_data=self.state.grid_data,
@@ -481,9 +479,9 @@ class Driver:
                 phis=self.state.dycore_state.phis,
                 state=self.state.dycore_state,
             )
-            logger.info("setting up dycore object done")
+            pace_log.info("setting up dycore object done")
 
-            logger.info("setting up physics object started")
+            pace_log.info("setting up physics object started")
             if not config.dycore_only and not config.disable_step_physics:
                 self.physics = pace.physics.Physics(
                     stencil_factory=self.stencil_factory,
@@ -519,12 +517,12 @@ class Driver:
                 # Make sure those are set to None to raise any issues
                 self.dycore_to_physics = None
                 self.end_of_step_update = None
-            logger.info("setting up physics object done")
-            logger.info("setting up diagnostics factory started")
+            pace_log.info("setting up physics object done")
+            pace_log.info("setting up diagnostics factory started")
             self.diagnostics = config.diagnostics_config.diagnostics_factory(
                 communicator=communicator
             )
-            logger.info("setting up diagnostics factory done")
+            pace_log.info("setting up diagnostics factory done")
         log_subtile_location(
             partitioner=communicator.partitioner.tile, rank=communicator.rank
         )
@@ -532,14 +530,14 @@ class Driver:
             self.diagnostics.store(time=self.time, state=self.state)
 
         self._time_run = self.config.start_time
-        logger.info("setting up safety checkers started")
+        pace_log.info("setting up safety checkers started")
         self.safety_checker = SafetyChecker()
         SafetyChecker.register_variable("ua", -200, 200, compute_domain_only=True)
         SafetyChecker.register_variable("va", -200, 200, compute_domain_only=True)
         SafetyChecker.register_variable("delp", -1.0, 4000, compute_domain_only=True)
         SafetyChecker.register_variable("pt", 100, 380, compute_domain_only=True)
-        logger.info("setting up safety checkers done")
-        logger.info("initialization of the object done")
+        pace_log.info("setting up safety checkers done")
+        pace_log.info("initialization of the object done")
 
     def _update_driver_config_with_communicator(
         self, communicator: CubedSphereCommunicator
@@ -576,11 +574,11 @@ class Driver:
         Using a method allows those actions to be removed from the orchestration path.
         """
         if __debug__:
-            logger.info(f"Finished stepping {step}")
+            pace_log.info(f"Finished stepping {step}")
         self.performance_collector.collect_performance()
         self.time += self.config.timestep
         if ((step + 1) % self.config.output_frequency) == 0:
-            logger.info(f"diagnostics for step {self.time} started")
+            pace_log.info(f"diagnostics for step {self.time} started")
             self.performance_collector.write_out_rank_0(
                 self.config.stencil_config.compilation_config.backend,
                 self.config.stencil_config.dace_config.is_dace_orchestrated(),
@@ -588,13 +586,13 @@ class Driver:
                 "Ongoing",
             )
             self.diagnostics.store(time=self.time, state=self.state)
-            logger.info(f"diagnostics for step {self.time} finished")
+            pace_log.info(f"diagnostics for step {self.time} finished")
         if (
             self.config.safety_check_frequency
             and ((step + 1) % self.config.safety_check_frequency) == 0
         ):
             self.safety_checker.check_state(self.state.dycore_state)
-            logger.info(f"checking state for for step {step+1} finished")
+            pace_log.info(f"checking state for for step {step+1} finished")
         self.config.restart_config.write_intermediate_if_enabled(
             state=self.state,
             step=step,
@@ -642,7 +640,7 @@ class Driver:
             self._end_of_step_actions(step)
 
     def step_all(self):
-        logger.info("integrating driver forward in time")
+        pace_log.info("integrating driver forward in time")
         with self.performance_collector.total_timer.clock("total"):
             self.profiler.enable()
             PerformanceCollector.mark_cuda_profiler("Begin integration")
@@ -667,7 +665,7 @@ class Driver:
 
     @dace_inhibitor
     def cleanup(self):
-        logger.info("cleaning up driver")
+        pace_log.info("cleaning up driver")
         self.performance_collector.write_out_rank_0(
             self.config.stencil_config.compilation_config.backend,
             self.config.stencil_config.dace_config.is_dace_orchestrated(),
@@ -700,7 +698,7 @@ def log_subtile_location(partitioner: pace.util.TilePartitioner, rank: int):
         "east": partitioner.on_tile_right(rank),
         "west": partitioner.on_tile_left(rank),
     }
-    logger.info(f"running on rank {rank} with subtile location {location_info}")
+    pace_log.info(f"running on rank {rank} with subtile location {location_info}")
 
 
 def _setup_factories(

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -21,7 +21,7 @@ from pace.driver.safety_checks import SafetyChecker
 from pace.dsl.dace.dace_config import DaceConfig
 from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.stencil_config import CompilationConfig, RunMode
-from pace.dsl.typing import Float, global_set_floating_point_precision
+from pace.dsl.typing import Float
 
 # TODO: move update_atmos_state into pace.driver
 from pace.stencils import update_atmos_state
@@ -92,7 +92,6 @@ class DriverConfig:
     nz: int
     layout: Tuple[int, int]
     dt_atmos: float
-    floating_point_precision_in_bit: int = 64
     grid_config: GridInitializerSelector = dataclasses.field(
         default_factory=lambda: GridInitializerSelector(
             type="generated", config=GeneratedGridConfig()
@@ -385,7 +384,6 @@ class Driver:
         """
         logger.info("initializing driver")
         self.config: DriverConfig = config
-        global_set_floating_point_precision(config.floating_point_precision_in_bit)
         self.time = self.config.start_time
         self.comm_config = config.comm_config
         global_comm = config.comm_config.get_comm()

--- a/driver/pace/driver/grid.py
+++ b/driver/pace/driver/grid.py
@@ -1,6 +1,5 @@
 import abc
 import dataclasses
-import logging
 from typing import ClassVar, Optional, Tuple
 
 import f90nml
@@ -25,12 +24,10 @@ from pace.util.grid.helper import (
     HorizontalGridData,
     VerticalGridData,
 )
+from pace.util.logging import pace_log
 from pace.util.namelist import Namelist
 
 from .registry import Registry
-
-
-logger = logging.getLogger(__name__)
 
 
 class GridInitializer(abc.ABC):
@@ -179,7 +176,7 @@ class SerialboxGridConfig(GridInitializer):
             dims=[pace.util.X_DIM, pace.util.Y_DIM], units="unknown"
         ).gt4py_backend
 
-        logger.info("Using serialized grid data")
+        pace_log.info("Using serialized grid data")
         grid = self._get_serialized_grid(communicator, backend)
         grid_data = grid.grid_data
         driver_grid_data = grid.driver_grid_data

--- a/driver/pace/driver/initialization.py
+++ b/driver/pace/driver/initialization.py
@@ -1,6 +1,5 @@
 import abc
 import dataclasses
-import logging
 import os
 import pathlib
 from datetime import datetime
@@ -26,9 +25,6 @@ from pace.util.namelist import Namelist
 
 from .registry import Registry
 from .state import DriverState, TendencyState, _restart_driver_state
-
-
-logger = logging.getLogger(__name__)
 
 
 class Initializer(abc.ABC):

--- a/driver/pace/driver/safety_checks.py
+++ b/driver/pace/driver/safety_checks.py
@@ -1,13 +1,9 @@
-import logging
 from typing import ClassVar, Dict, Optional
 
 import numpy as np
 
 from pace.fv3core.initialization.dycore_state import DycoreState
 from pace.util.quantity import Quantity
-
-
-logger = logging.getLogger(__name__)
 
 
 class VariableBounds:

--- a/driver/pace/driver/state.py
+++ b/driver/pace/driver/state.py
@@ -8,6 +8,7 @@ import pace.physics
 import pace.util
 import pace.util.grid
 from pace import fv3core
+from pace.dsl.typing import Float
 
 
 @dataclasses.dataclass()
@@ -49,7 +50,7 @@ class TendencyState:
             initial_quantities[_field.name] = quantity_factory.zeros(
                 _field.metadata["dims"],
                 _field.metadata["units"],
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
         return cls(**initial_quantities)
 

--- a/driver/pace/driver/state.py
+++ b/driver/pace/driver/state.py
@@ -49,7 +49,7 @@ class TendencyState:
             initial_quantities[_field.name] = quantity_factory.zeros(
                 _field.metadata["dims"],
                 _field.metadata["units"],
-                dtype=float,
+                dtype=pace.util.pfloat(),
             )
         return cls(**initial_quantities)
 

--- a/dsl/pace/dsl/dace/__init__.py
+++ b/dsl/pace/dsl/dace/__init__.py
@@ -1,1 +1,2 @@
+from pace.dsl.dace.dace_config import DaceConfig
 from pace.dsl.dace.orchestration import orchestrate

--- a/dsl/pace/dsl/dace/build.py
+++ b/dsl/pace/dsl/dace/build.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Tuple
+from warnings import warn
 
 from dace.sdfg import SDFG
 
@@ -164,9 +165,9 @@ def get_sdfg_path(
         ):
             can_read = False
         if not can_read:
-            raise RuntimeError(
+            warn(
                 f"SDFG build for layout {build_layout}, "
-                f"cannot be run with current layout {config.layout}"
+                f"cannot be run with current layout {config.layout}, bad layout?"
             )
         # Check resolution per tile
         build_resolution = ast.literal_eval(build_info_file.readline())

--- a/dsl/pace/dsl/dace/build.py
+++ b/dsl/pace/dsl/dace/build.py
@@ -124,7 +124,7 @@ def get_sdfg_path(
         return sdfg_file_path
 
     # Case of loading a precompiled .so - lookup using GT_CACHE
-    from gt4py import config as gt_config
+    from gt4py.cartesian import config as gt_config
 
     if config.rank_size > 1:
         rank = config.my_rank
@@ -194,7 +194,7 @@ def set_distributed_caches(config: "DaceConfig"):
     if orchestration_mode == DaCeOrchestration.Run:
         import os
 
-        from gt4py import config as gt_config
+        from gt4py.cartesian import config as gt_config
 
         # Check our cache exist
         if config.rank_size > 1:

--- a/dsl/pace/dsl/dace/dace_config.py
+++ b/dsl/pace/dsl/dace/dace_config.py
@@ -2,6 +2,8 @@ import enum
 from typing import Any, Dict, Optional
 
 import dace.config
+from dace.codegen.compiled_sdfg import CompiledSDFG
+from dace.frontend.python.parser import DaceProgram
 
 from pace.dsl.gt4py_utils import is_gpu_backend
 from pace.util.communicator import CubedSphereCommunicator
@@ -29,6 +31,28 @@ class DaCeOrchestration(enum.Enum):
     Run = 3
 
 
+class FrozenCompiledSDFG:
+    """
+    Cache transform args to allow direct execution of the CSDFG
+
+    Args:
+        csdfg: compiled SDFG, e.g. loaded .so
+        sdfg_args: transformed args to align for CSDFG direct execution
+
+    WARNING: No checks are done on arguments, any memory swap (free/realloc)
+    will lead to difficult to debug misbehavior
+    """
+
+    def __init__(
+        self, daceprog: DaceProgram, csdfg: CompiledSDFG, args, kwargs
+    ) -> None:
+        self.csdfg = csdfg
+        self.sdfg_args = daceprog._create_sdfg_args(csdfg.sdfg, args, kwargs)
+
+    def __call__(self):
+        return self.csdfg(**self.sdfg_args)
+
+
 class DaceConfig:
     def __init__(
         self,
@@ -38,6 +62,11 @@ class DaceConfig:
         tile_nz: int = 0,
         orchestration: Optional[DaCeOrchestration] = None,
     ):
+        # Recording SDFG loaded for fast re-access
+        # ToDo: DaceConfig becomes a bit more than a read-only config
+        #       with this. Should be refactor into a DaceExecutor carrying a config
+        self.loaded_precompiled_SDFG: Dict[DaceProgram, FrozenCompiledSDFG] = {}
+
         # Temporary. This is a bit too out of the ordinary for the common user.
         # We should refactor the architecture to allow for a `gtc:orchestrated:dace:X`
         # backend that would signify both the `CPU|GPU` split and the orchestration mode

--- a/dsl/pace/dsl/dace/orchestration.py
+++ b/dsl/pace/dsl/dace/orchestration.py
@@ -21,6 +21,7 @@ from pace.dsl.dace.dace_config import (
     DEACTIVATE_DISTRIBUTED_DACE_COMPILE,
     DaceConfig,
     DaCeOrchestration,
+    FrozenCompiledSDFG,
 )
 from pace.dsl.dace.sdfg_debug_passes import (
     negative_delp_checker,
@@ -114,11 +115,11 @@ def _to_gpu(sdfg: dace.SDFG):
         sd.openmp_sections = False
 
 
-def _run_sdfg(daceprog: DaceProgram, config: DaceConfig, args, kwargs):
+def _run_sdfg(dace_executable: DaceProgram, config: DaceConfig, args, kwargs):
     """Execute a compiled SDFG - do not check for compilation"""
     if config.is_gpu_backend():
         _upload_to_device(list(args) + list(kwargs.values()))
-    res = daceprog(*args, **kwargs)
+    res = dace_executable(*args, **kwargs)
     return _download_results_from_dace(config, res, list(args) + list(kwargs.values()))
 
 
@@ -252,19 +253,33 @@ def _call_sdfg(
     daceprog: DaceProgram, sdfg: dace.SDFG, config: DaceConfig, args, kwargs
 ):
     """Dispatch the SDFG execution and/or build"""
-    if (
-        config.get_orchestrate() == DaCeOrchestration.Build
-        or config.get_orchestrate() == DaCeOrchestration.BuildAndRun
-    ):
-        return _build_sdfg(daceprog, sdfg, config, args, kwargs)
-    elif config.get_orchestrate() == DaCeOrchestration.Run:
+    # Pre-compiled SDFG code path does away with any data checks and
+    # cached the marshalling - leading to almost direct C call
+    # DaceProgram performs argument transformation & checks for a cost ~200ms
+    # of overhead
+    if daceprog in config.loaded_precompiled_SDFG:
         with DaCeProgress(config, "Run"):
-            res = _run_sdfg(daceprog, config, args, kwargs)
+            if config.is_gpu_backend():
+                _upload_to_device(list(args) + list(kwargs.values()))
+            res = config.loaded_precompiled_SDFG[daceprog]()
+            res = _download_results_from_dace(
+                config, res, list(args) + list(kwargs.values())
+            )
         return res
     else:
-        raise NotImplementedError(
-            f"Mode {config.get_orchestrate()} unimplemented at call time"
-        )
+        if (
+            config.get_orchestrate() == DaCeOrchestration.Build
+            or config.get_orchestrate() == DaCeOrchestration.BuildAndRun
+        ):
+            res = _build_sdfg(daceprog, sdfg, config, args, kwargs)
+        elif config.get_orchestrate() == DaCeOrchestration.Run:
+            with DaCeProgress(config, "Run"):
+                res = _run_sdfg(daceprog, config, args, kwargs)
+        else:
+            raise NotImplementedError(
+                f"Mode {config.get_orchestrate()} unimplemented at call time"
+            )
+        return res
 
 
 def _parse_sdfg(
@@ -280,6 +295,11 @@ def _parse_sdfg(
         daceprog: the DaceProgram carrying reference to the original method/function
         config: the DaceConfig configuration for this execution
     """
+    # Check cache for already loaded SDFG
+    if daceprog in config.loaded_precompiled_SDFG:
+        return config.loaded_precompiled_SDFG[daceprog]
+
+    # Build expected path
     sdfg_path = get_sdfg_path(daceprog.name, config)
     if sdfg_path is None:
         if DEACTIVATE_DISTRIBUTED_DACE_COMPILE:
@@ -307,6 +327,9 @@ def _parse_sdfg(
         else:
             with DaCeProgress(config, "Load precompiled .sdfg (.so)"):
                 csdfg, _ = daceprog.load_precompiled_sdfg(sdfg_path, *args, **kwargs)
+                config.loaded_precompiled_SDFG[daceprog] = FrozenCompiledSDFG(
+                    daceprog, csdfg, args, kwargs
+                )
             return csdfg
 
 

--- a/dsl/pace/dsl/dace/sdfg_debug_passes.py
+++ b/dsl/pace/dsl/dace/sdfg_debug_passes.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 from typing import List, Tuple
 
 import dace
@@ -10,8 +9,7 @@ from dace.sdfg import graph as gr
 from dace.sdfg import utils as sdutil
 from dace.transformation.helpers import get_parent_map
 
-
-logger = logging.getLogger(__name__)
+from pace.util.logging import pace_log
 
 
 def _filter_all_maps(
@@ -179,7 +177,7 @@ def trace_all_outputs_at_index(sdfg: dace.SDFG, i: int, j: int, k: int):
             assert_out=False,
         )
 
-    logger.info(f"Added {len(all_maps_filtered)} outputs trace at {i},{j},{k}")
+    pace_log.info(f"Added {len(all_maps_filtered)} outputs trace at {i},{j},{k}")
 
 
 def negative_delp_checker(sdfg: dace.SDFG) -> None:
@@ -205,7 +203,7 @@ def negative_delp_checker(sdfg: dace.SDFG) -> None:
             assert_out=True,
         )
 
-    logger.info(f"Added {len(all_maps_filtered)} delp* < 0 checks")
+    pace_log.info(f"Added {len(all_maps_filtered)} delp* < 0 checks")
 
 
 def negative_qtracers_checker(sdfg: dace.SDFG):
@@ -241,7 +239,7 @@ def negative_qtracers_checker(sdfg: dace.SDFG):
             assert_out=True,
         )
 
-    logger.info(f"Added {len(all_maps_filtered)} tracer < 0 checks")
+    pace_log.info(f"Added {len(all_maps_filtered)} tracer < 0 checks")
 
 
 def sdfg_nan_checker(sdfg: dace.SDFG):
@@ -266,4 +264,4 @@ def sdfg_nan_checker(sdfg: dace.SDFG):
             assert_out=True,
         )
 
-    logger.info(f"Added {len(all_maps_filtered)} NaN checks")
+    pace_log.info(f"Added {len(all_maps_filtered)} NaN checks")

--- a/dsl/pace/dsl/dace/sdfg_opt_passes.py
+++ b/dsl/pace/dsl/dace/sdfg_opt_passes.py
@@ -1,9 +1,6 @@
-import logging
-
 import dace
 
-
-logger = logging.getLogger(__name__)
+from pace.util.logging import pace_log
 
 
 def splittable_region_expansion(sdfg: dace.SDFG, verbose: bool = False):
@@ -24,4 +21,4 @@ def splittable_region_expansion(sdfg: dace.SDFG, verbose: bool = False):
                     "K",
                 ]
                 if verbose:
-                    logger.info(f"Reordered schedule for {node.label}")
+                    pace_log.info(f"Reordered schedule for {node.label}")

--- a/dsl/pace/dsl/dace/utils.py
+++ b/dsl/pace/dsl/dace/utils.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from dataclasses import dataclass, field
 from typing import Dict, List
@@ -7,9 +6,8 @@ import dace
 from dace.transformation.helpers import get_parent_map
 
 from pace.dsl.dace.dace_config import DaceConfig
+from pace.util.logging import pace_log
 
-
-logger = logging.getLogger(__name__)
 
 # Rough timer & log for major operations of DaCe build stack
 class DaCeProgress:
@@ -22,7 +20,7 @@ class DaCeProgress:
 
     @classmethod
     def log(cls, prefix: str, message: str):
-        logger.info(f"{prefix} {message}")
+        pace_log.info(f"{prefix} {message}")
 
     @classmethod
     def default_prefix(cls, config: DaceConfig) -> str:

--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -6,6 +6,7 @@ import gt4py
 import numpy as np
 
 from pace.dsl.typing import DTypes, Field, Float
+from pace.util.utils import pfloat
 
 
 try:
@@ -83,7 +84,7 @@ def make_storage_data(
     origin: Tuple[int, ...] = origin,
     *,
     backend: str,
-    dtype: DTypes = np.float64,
+    dtype: DTypes = pfloat(),
     mask: Optional[Tuple[bool, ...]] = None,
     start: Tuple[int, ...] = (0, 0, 0),
     dummy: Optional[Tuple[int, ...]] = None,
@@ -261,7 +262,7 @@ def make_storage_from_shape(
     origin: Tuple[int, ...] = origin,
     *,
     backend: str,
-    dtype: DTypes = np.float64,
+    dtype: DTypes = pfloat(),
     mask: Optional[Tuple[bool, ...]] = None,
 ) -> Field:
     """Create a new gt4py storage of a given shape filled with zeros.

--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -1,4 +1,3 @@
-import logging
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -6,6 +5,7 @@ import gt4py
 import numpy as np
 
 from pace.dsl.typing import DTypes, Field, Float
+from pace.util.logging import pace_log
 
 
 try:
@@ -32,9 +32,6 @@ tracer_variables = [
     "qsgs_tke",
     "qcld",
 ]
-
-# Logger instance
-logger = logging.getLogger("fv3core")
 
 
 def mark_untested(msg="This is not tested"):
@@ -357,7 +354,7 @@ def k_split_run(func, data, k_indices, splitvars_values):
         data.update(splitvars)
         data["kstart"] = ki
         data["nk"] = nk
-        logger.debug(
+        pace_log.debug(
             "Running kstart: {}, num k:{}, variables:{}".format(ki, nk, splitvars)
         )
         func(**data)

--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -6,7 +6,6 @@ import gt4py
 import numpy as np
 
 from pace.dsl.typing import DTypes, Field, Float
-from pace.util.utils import pfloat
 
 
 try:
@@ -84,7 +83,7 @@ def make_storage_data(
     origin: Tuple[int, ...] = origin,
     *,
     backend: str,
-    dtype: DTypes = pfloat(),
+    dtype: DTypes = Float,
     mask: Optional[Tuple[bool, ...]] = None,
     start: Tuple[int, ...] = (0, 0, 0),
     dummy: Optional[Tuple[int, ...]] = None,
@@ -262,7 +261,7 @@ def make_storage_from_shape(
     origin: Tuple[int, ...] = origin,
     *,
     backend: str,
-    dtype: DTypes = pfloat(),
+    dtype: DTypes = Float,
     mask: Optional[Tuple[bool, ...]] = None,
 ) -> Field:
     """Create a new gt4py storage of a given shape filled with zeros.

--- a/dsl/pace/dsl/stencil.py
+++ b/dsl/pace/dsl/stencil.py
@@ -342,6 +342,7 @@ class FrozenStencil(SDFGConvertible):
             self.stencil_object = gtscript.lazy_stencil(
                 definition=func,
                 externals=externals,
+                dtypes={float: pace.util.pfloat()},
                 **stencil_kwargs,
                 build_info=(build_info := {}),  # type: ignore
             )
@@ -357,6 +358,7 @@ class FrozenStencil(SDFGConvertible):
             self.stencil_object = gtscript.stencil(
                 definition=func,
                 externals=externals,
+                dtypes={float: pace.util.pfloat()},
                 **stencil_kwargs,
                 build_info=(build_info := {}),
             )

--- a/dsl/pace/dsl/stencil.py
+++ b/dsl/pace/dsl/stencil.py
@@ -25,7 +25,7 @@ from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline, OirPipeline
 import pace.util
 from pace.dsl.dace.orchestration import SDFGConvertible
 from pace.dsl.stencil_config import CompilationConfig, RunMode, StencilConfig
-from pace.dsl.typing import Index3D, cast_to_index3d
+from pace.dsl.typing import Float, Index3D, cast_to_index3d
 from pace.util import testing
 from pace.util.decomposition import block_waiting_for_compilation, unblock_waiting_tiles
 from pace.util.mpi import MPI
@@ -342,7 +342,7 @@ class FrozenStencil(SDFGConvertible):
             self.stencil_object = gtscript.lazy_stencil(
                 definition=func,
                 externals=externals,
-                dtypes={float: pace.util.pfloat()},
+                dtypes={float: Float},
                 **stencil_kwargs,
                 build_info=(build_info := {}),  # type: ignore
             )
@@ -358,7 +358,7 @@ class FrozenStencil(SDFGConvertible):
             self.stencil_object = gtscript.stencil(
                 definition=func,
                 externals=externals,
-                dtypes={float: pace.util.pfloat()},
+                dtypes={float: Float},
                 **stencil_kwargs,
                 build_info=(build_info := {}),
             )

--- a/dsl/pace/dsl/typing.py
+++ b/dsl/pace/dsl/typing.py
@@ -21,7 +21,7 @@ K = gtscript.K  # noqa: E741
 DTypes = Union[bool, np.bool_, int, np.int32, np.int64, float, np.float32, np.float64]
 
 # Default float and int types
-Float = np.float_
+Float = np.float32
 Int = np.int_
 Bool = np.bool_
 

--- a/dsl/pace/dsl/typing.py
+++ b/dsl/pace/dsl/typing.py
@@ -1,3 +1,4 @@
+import os
 from typing import Tuple, Union, cast
 
 import gt4py.cartesian.gtscript as gtscript
@@ -20,21 +21,24 @@ K = gtscript.K  # noqa: E741
 # Union of valid data types (from gt4py.cartesian.gtscript)
 DTypes = Union[bool, np.bool_, int, np.int32, np.int64, float, np.float32, np.float64]
 
-# Default float and int types
-Float = np.float64
-Int = np.int_
-Bool = np.bool_
 
-
-def global_set_floating_point_precision(precision_in_bit: int):
+def global_set_floating_point_precision():
+    global Float
+    precision_in_bit = int(os.getenv("PACE_FLOAT_PRECISION", "64"))
     if precision_in_bit == 64:
-        return
-    if precision_in_bit == 32:
-        global Float
+        Float = np.float64
+    elif precision_in_bit == 32:
         Float = np.float32
     else:
-        raise NotImplementedError(f"Precision of {precision_in_bit} bit is untested")
+        NotImplementedError(
+            f"{precision_in_bit} bit precision not implemented or tested"
+        )
 
+
+# Default float and int types
+Float = global_set_floating_point_precision()
+Int = np.int_
+Bool = np.bool_
 
 FloatField = Field[gtscript.IJK, Float]
 FloatFieldI = Field[gtscript.I, Float]

--- a/dsl/pace/dsl/typing.py
+++ b/dsl/pace/dsl/typing.py
@@ -21,7 +21,7 @@ K = gtscript.K  # noqa: E741
 DTypes = Union[bool, np.bool_, int, np.int32, np.int64, float, np.float32, np.float64]
 
 # Default float and int types
-Float = np.float32
+Float = np.float64
 Int = np.int_
 Bool = np.bool_
 

--- a/dsl/pace/dsl/typing.py
+++ b/dsl/pace/dsl/typing.py
@@ -26,13 +26,14 @@ def global_set_floating_point_precision():
     global Float
     precision_in_bit = int(os.getenv("PACE_FLOAT_PRECISION", "64"))
     if precision_in_bit == 64:
-        Float = np.float64
+        return np.float64
     elif precision_in_bit == 32:
-        Float = np.float32
+        return np.float32
     else:
         NotImplementedError(
             f"{precision_in_bit} bit precision not implemented or tested"
         )
+    return None
 
 
 # Default float and int types

--- a/dsl/pace/dsl/typing.py
+++ b/dsl/pace/dsl/typing.py
@@ -26,6 +26,16 @@ Int = np.int_
 Bool = np.bool_
 
 
+def global_set_floating_point_precision(precision_in_bit: int):
+    if precision_in_bit == 64:
+        pass
+    if precision_in_bit == 32:
+        global Float
+        Float = np.float32
+    else:
+        raise NotImplementedError(f"Precision of {precision_in_bit} bit is untested")
+
+
 FloatField = Field[gtscript.IJK, Float]
 FloatFieldI = Field[gtscript.I, Float]
 FloatFieldJ = Field[gtscript.J, Float]

--- a/dsl/pace/dsl/typing.py
+++ b/dsl/pace/dsl/typing.py
@@ -23,6 +23,8 @@ DTypes = Union[bool, np.bool_, int, np.int32, np.int64, float, np.float32, np.fl
 
 
 def global_set_floating_point_precision():
+    """Set the global floating point precision for all reference
+    to Float in the codebase. Defaults to 64 bit."""
     global Float
     precision_in_bit = int(os.getenv("PACE_FLOAT_PRECISION", "64"))
     if precision_in_bit == 64:

--- a/dsl/pace/dsl/typing.py
+++ b/dsl/pace/dsl/typing.py
@@ -28,7 +28,7 @@ Bool = np.bool_
 
 def global_set_floating_point_precision(precision_in_bit: int):
     if precision_in_bit == 64:
-        pass
+        return
     if precision_in_bit == 32:
         global Float
         Float = np.float32

--- a/fv3core/pace/fv3core/initialization/baroclinic.py
+++ b/fv3core/pace/fv3core/initialization/baroclinic.py
@@ -428,7 +428,10 @@ def empty_numpy_dycore_state(shape):
     numpy_dict = {}
     for _field in fields(DycoreState):
         if "dims" in _field.metadata.keys():
-            numpy_dict[_field.name] = np.zeros(shape[: len(_field.metadata["dims"])])
+            numpy_dict[_field.name] = np.zeros(
+                shape[: len(_field.metadata["dims"])],
+                dtype=fv3util.pfloat(),
+            )
     numpy_state = SimpleNamespace(**numpy_dict)
     return numpy_state
 

--- a/fv3core/pace/fv3core/initialization/baroclinic.py
+++ b/fv3core/pace/fv3core/initialization/baroclinic.py
@@ -8,6 +8,7 @@ import pace.dsl.gt4py_utils as utils
 import pace.fv3core.initialization.baroclinic_jablonowski_williamson as jablo_init
 import pace.util as fv3util
 import pace.util.constants as constants
+from pace.dsl.typing import Float
 from pace.fv3core.initialization.dycore_state import DycoreState
 from pace.util.grid import GridData, lon_lat_midpoint
 
@@ -430,7 +431,7 @@ def empty_numpy_dycore_state(shape):
         if "dims" in _field.metadata.keys():
             numpy_dict[_field.name] = np.zeros(
                 shape[: len(_field.metadata["dims"])],
-                dtype=fv3util.pfloat(),
+                dtype=Float,
             )
     numpy_state = SimpleNamespace(**numpy_dict)
     return numpy_state

--- a/fv3core/pace/fv3core/initialization/dycore_state.py
+++ b/fv3core/pace/fv3core/initialization/dycore_state.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 import pace.dsl.gt4py_utils as gt_utils
 import pace.util
+from pace.dsl.typing import Float
 
 
 @dataclass()
@@ -306,7 +307,7 @@ class DycoreState:
                 initial_storages[_field.name] = quantity_factory.zeros(
                     _field.metadata["dims"],
                     _field.metadata["units"],
-                    dtype=pace.util.pfloat(),
+                    dtype=Float,
                 ).data
         return cls.init_from_storages(
             storages=initial_storages, sizer=quantity_factory.sizer

--- a/fv3core/pace/fv3core/initialization/dycore_state.py
+++ b/fv3core/pace/fv3core/initialization/dycore_state.py
@@ -304,7 +304,9 @@ class DycoreState:
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
                 initial_storages[_field.name] = quantity_factory.zeros(
-                    _field.metadata["dims"], _field.metadata["units"], dtype=float
+                    _field.metadata["dims"],
+                    _field.metadata["units"],
+                    dtype=pace.util.pfloat(),
                 ).data
         return cls.init_from_storages(
             storages=initial_storages, sizer=quantity_factory.sizer

--- a/fv3core/pace/fv3core/initialization/geos_wrapper.py
+++ b/fv3core/pace/fv3core/initialization/geos_wrapper.py
@@ -8,6 +8,7 @@ import pace.util
 from pace import fv3core
 from pace.driver.performance.collector import PerformanceCollector
 from pace.dsl.dace.dace_config import DaceConfig
+from pace.dsl.typing import global_set_floating_point_precision
 
 
 class GeosDycoreWrapper:
@@ -16,7 +17,16 @@ class GeosDycoreWrapper:
     Takes numpy arrays as inputs, returns a dictionary of numpy arrays as outputs
     """
 
-    def __init__(self, namelist: f90nml.Namelist, comm: pace.util.Comm, backend: str):
+    def __init__(
+        self,
+        namelist: f90nml.Namelist,
+        comm: pace.util.Comm,
+        backend: str,
+        fprecision: int = 64,
+    ):
+        # Set floating point precision of the dycore
+        global_set_floating_point_precision(fprecision)
+
         # Make a custom performance collector for the GEOS wrapper
         self.perf_collector = PerformanceCollector("GEOS wrapper", comm)
 

--- a/fv3core/pace/fv3core/initialization/geos_wrapper.py
+++ b/fv3core/pace/fv3core/initialization/geos_wrapper.py
@@ -20,6 +20,7 @@ class GeosDycoreWrapper:
     def __init__(
         self,
         namelist: f90nml.Namelist,
+        bdt: int,
         comm: pace.util.Comm,
         backend: str,
     ):
@@ -34,6 +35,8 @@ class GeosDycoreWrapper:
         self.backend = backend
         self.namelist = namelist
         self.dycore_config = fv3core.DynamicalCoreConfig.from_f90nml(self.namelist)
+        self.dycore_config.dt_atmos = bdt
+        assert self.dycore_config.dt_atmos != 0
 
         self.layout = self.dycore_config.layout
         partitioner = pace.util.CubedSpherePartitioner(

--- a/fv3core/pace/fv3core/initialization/geos_wrapper.py
+++ b/fv3core/pace/fv3core/initialization/geos_wrapper.py
@@ -9,7 +9,6 @@ import pace.util
 from pace import fv3core
 from pace.driver.performance.collector import PerformanceCollector
 from pace.dsl.dace import DaceConfig, orchestrate
-from pace.dsl.typing import global_set_floating_point_precision
 
 
 class GeosDycoreWrapper:
@@ -25,9 +24,6 @@ class GeosDycoreWrapper:
         backend: str,
         fprecision: int = 64,
     ):
-        # Set floating point precision of the dycore
-        global_set_floating_point_precision(fprecision)
-
         # Look for an override to run on a single node
         gtfv3_single_rank_override = int(os.getenv("GTFV3_SINGLE_RANK_OVERRIDE", -1))
         if gtfv3_single_rank_override >= 0:

--- a/fv3core/pace/fv3core/initialization/geos_wrapper.py
+++ b/fv3core/pace/fv3core/initialization/geos_wrapper.py
@@ -22,7 +22,6 @@ class GeosDycoreWrapper:
         namelist: f90nml.Namelist,
         comm: pace.util.Comm,
         backend: str,
-        fprecision: int = 64,
     ):
         # Look for an override to run on a single node
         gtfv3_single_rank_override = int(os.getenv("GTFV3_SINGLE_RANK_OVERRIDE", -1))

--- a/fv3core/pace/fv3core/initialization/geos_wrapper.py
+++ b/fv3core/pace/fv3core/initialization/geos_wrapper.py
@@ -1,3 +1,4 @@
+import os
 from datetime import timedelta
 from typing import Dict
 
@@ -7,7 +8,7 @@ import numpy as np
 import pace.util
 from pace import fv3core
 from pace.driver.performance.collector import PerformanceCollector
-from pace.dsl.dace.dace_config import DaceConfig
+from pace.dsl.dace import DaceConfig, orchestrate
 from pace.dsl.typing import global_set_floating_point_precision
 
 
@@ -27,6 +28,11 @@ class GeosDycoreWrapper:
         # Set floating point precision of the dycore
         global_set_floating_point_precision(fprecision)
 
+        # Look for an override to run on a single node
+        gtfv3_single_rank_override = int(os.getenv("GTFV3_SINGLE_RANK_OVERRIDE", -1))
+        if gtfv3_single_rank_override >= 0:
+            comm = pace.util.NullComm(gtfv3_single_rank_override, 6, 42)
+
         # Make a custom performance collector for the GEOS wrapper
         self.perf_collector = PerformanceCollector("GEOS wrapper", comm)
 
@@ -39,7 +45,9 @@ class GeosDycoreWrapper:
             pace.util.TilePartitioner(self.layout)
         )
         self.communicator = pace.util.CubedSphereCommunicator(
-            comm, partitioner, timer=self.perf_collector.timestep_timer
+            comm,
+            partitioner,
+            timer=self.perf_collector.timestep_timer,
         )
 
         sizer = pace.util.SubtileGridSizer.from_namelist(
@@ -61,11 +69,22 @@ class GeosDycoreWrapper:
             ),
         )
 
+        # Build a DaCeConfig for orchestration.
+        # This and all orchestration code are transparent when outside
+        # configuration deactivate orchestration
         stencil_config.dace_config = DaceConfig(
             communicator=self.communicator,
             backend=stencil_config.backend,
             tile_nx=self.dycore_config.npx,
             tile_nz=self.dycore_config.npz,
+        )
+        self._is_orchestrated = stencil_config.dace_config.is_dace_orchestrated()
+
+        # Orchestrate all code called from this function
+        orchestrate(
+            obj=self,
+            config=stencil_config.dace_config,
+            method_to_orchestrate="_critical_path",
         )
 
         self._grid_indexing = pace.dsl.stencil.GridIndexing.from_sizer_and_communicator(
@@ -78,18 +97,6 @@ class GeosDycoreWrapper:
         self.dycore_state = fv3core.DycoreState.init_zeros(
             quantity_factory=quantity_factory
         )
-
-        self.dycore_state.bdt = float(namelist["dt_atmos"])
-        if "fv_core_nml" in namelist.keys():
-            self.dycore_state.bdt = (
-                float(namelist["dt_atmos"]) / namelist["fv_core_nml"]["k_split"]
-            )
-        elif "dycore_config" in namelist.keys():
-            self.dycore_state.bdt = (
-                float(namelist["dt_atmos"]) / namelist["dycore_config"]["k_split"]
-            )
-        else:
-            raise KeyError("Cannot find k_split in namelist")
 
         damping_coefficients = pace.util.grid.DampingCoefficients.new_from_metric_terms(
             metric_terms
@@ -109,6 +116,14 @@ class GeosDycoreWrapper:
 
         self.output_dict: Dict[str, np.ndarray] = {}
         self._allocate_output_dir()
+
+    def _critical_path(self):
+        """Top-level orchestration function"""
+        with self.perf_collector.timestep_timer.clock("dycore"):
+            self.dynamical_core.step_dynamics(
+                state=self.dycore_state,
+                timer=self.perf_collector.timestep_timer,
+            )
 
     def __call__(
         self,
@@ -166,10 +181,8 @@ class GeosDycoreWrapper:
                 diss_estd,
             )
 
-        with self.perf_collector.timestep_timer.clock("dycore"):
-            self.dynamical_core.step_dynamics(
-                state=self.dycore_state, timer=self.perf_collector.timestep_timer
-            )
+        # Enter orchestrated code - if applicable
+        self._critical_path()
 
         with self.perf_collector.timestep_timer.clock("move_to_fortran"):
             self.output_dict = self._prep_outputs_for_geos()
@@ -179,7 +192,7 @@ class GeosDycoreWrapper:
         self.perf_collector.collect_performance()
         self.perf_collector.write_out_rank_0(
             backend=self.backend,
-            is_orchestrated=False,  # could be infered from config
+            is_orchestrated=self._is_orchestrated,
             dt_atmos=self.dycore_config.dt_atmos,
             sim_status="Ongoing",
         )

--- a/fv3core/pace/fv3core/stencils/a2b_ord4.py
+++ b/fv3core/pace/fv3core/stencils/a2b_ord4.py
@@ -14,7 +14,7 @@ from gt4py.cartesian.gtscript import (
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import GridIndexing, StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldI, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldI, FloatFieldIJ
 from pace.fv3core.stencils.basic_operations import copy_defn
 from pace.util import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from pace.util.grid import GridData
@@ -550,19 +550,19 @@ class AGrid2BGridFourthOrder:
         self._tmp_qx = quantity_factory.zeros(
             dims=[X_INTERFACE_DIM, Y_DIM, z_dim],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._tmp_qy = quantity_factory.zeros(
             dims=[X_DIM, Y_INTERFACE_DIM, z_dim],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         # TODO: the dimensions of tmp_qout_edges may not be correct, verify
         # with Lucas and either update the code or remove this comment
         self._tmp_qout_edges = quantity_factory.zeros(
             dims=[X_DIM, Y_DIM, z_dim],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         _, (z_domain,) = self._idx.get_origin_domain([z_dim])

--- a/fv3core/pace/fv3core/stencils/a2b_ord4.py
+++ b/fv3core/pace/fv3core/stencils/a2b_ord4.py
@@ -548,15 +548,21 @@ class AGrid2BGridFourthOrder:
         self.replace = replace
 
         self._tmp_qx = quantity_factory.zeros(
-            dims=[X_INTERFACE_DIM, Y_DIM, z_dim], units="unknown"
+            dims=[X_INTERFACE_DIM, Y_DIM, z_dim],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
         self._tmp_qy = quantity_factory.zeros(
-            dims=[X_DIM, Y_INTERFACE_DIM, z_dim], units="unknown"
+            dims=[X_DIM, Y_INTERFACE_DIM, z_dim],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
         # TODO: the dimensions of tmp_qout_edges may not be correct, verify
         # with Lucas and either update the code or remove this comment
         self._tmp_qout_edges = quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM, z_dim], units="unknown"
+            dims=[X_DIM, Y_DIM, z_dim],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
 
         _, (z_domain,) = self._idx.get_origin_domain([z_dim])

--- a/fv3core/pace/fv3core/stencils/basic_operations.py
+++ b/fv3core/pace/fv3core/stencils/basic_operations.py
@@ -1,7 +1,7 @@
 import gt4py.cartesian.gtscript as gtscript
 from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 
 
 def copy_defn(q_in: FloatField, q_out: FloatField):
@@ -20,7 +20,7 @@ def adjustmentfactor_stencil_defn(adjustment: FloatFieldIJ, q_out: FloatField):
         q_out = q_out * adjustment
 
 
-def set_value_defn(q_out: FloatField, value: float):
+def set_value_defn(q_out: FloatField, value: Float):
     with computation(PARALLEL), interval(...):
         q_out = value
 

--- a/fv3core/pace/fv3core/stencils/c_sw.py
+++ b/fv3core/pace/fv3core/stencils/c_sw.py
@@ -10,7 +10,7 @@ from gt4py.cartesian.gtscript import (
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils.d2a2c_vect import DGrid2AGrid2CGridVectors
 from pace.stencils import corners
 from pace.util import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
@@ -503,7 +503,7 @@ class CGridShallowWaterDynamics:
         self.delpc = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         """
         pressure thickness on c-grid forward step
@@ -511,7 +511,7 @@ class CGridShallowWaterDynamics:
         self.ptc = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         """
         potential temperature on c-grid forward step
@@ -535,7 +535,7 @@ class CGridShallowWaterDynamics:
             return quantity_factory.zeros(
                 [X_DIM, Y_DIM, Z_DIM],
                 units="unknown",
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
 
         # TODO: double-check the dimensions on these, they may be incorrect

--- a/fv3core/pace/fv3core/stencils/c_sw.py
+++ b/fv3core/pace/fv3core/stencils/c_sw.py
@@ -500,11 +500,19 @@ class CGridShallowWaterDynamics:
         self._fC = self.grid_data.fC
         # TODO: double-check the dimensions on these, they may be incorrect
         # as they are only documentation and not used by the code
-        self.delpc = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+        self.delpc = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
         """
         pressure thickness on c-grid forward step
         """
-        self.ptc = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+        self.ptc = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
         """
         potential temperature on c-grid forward step
         """
@@ -524,7 +532,11 @@ class CGridShallowWaterDynamics:
         )
 
         def make_quantity() -> pace.util.Quantity:
-            return quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros(
+                [X_DIM, Y_DIM, Z_DIM],
+                units="unknown",
+                dtype=pace.util.pfloat(),
+            )
 
         # TODO: double-check the dimensions on these, they may be incorrect
         # as they are only documentation and not used by the code

--- a/fv3core/pace/fv3core/stencils/c_sw.py
+++ b/fv3core/pace/fv3core/stencils/c_sw.py
@@ -161,7 +161,7 @@ def geoadjust_ut(
     dy: FloatFieldIJ,
     sin_sg3: FloatFieldIJ,
     sin_sg1: FloatFieldIJ,
-    dt2: float,
+    dt2: Float,
 ):
     """
     take c-grid contravariant wind to compute the 1st order upwind flux
@@ -187,7 +187,7 @@ def geoadjust_vt(
     dx: FloatFieldIJ,
     sin_sg4: FloatFieldIJ,
     sin_sg2: FloatFieldIJ,
-    dt2: float,
+    dt2: Float,
 ):
     """
     Args:
@@ -288,7 +288,7 @@ def transportdelp_update_vorticity_and_kineticenergy(
     cos_sg3: FloatFieldIJ,
     sin_sg4: FloatFieldIJ,
     cos_sg4: FloatFieldIJ,
-    dt2: float,
+    dt2: Float,
 ):
     """Transport delp then update vorticity and kinetic energy
 
@@ -416,7 +416,7 @@ def update_x_velocity(
     cosa: FloatFieldIJ,
     sina: FloatFieldIJ,
     rdxc: FloatFieldIJ,
-    dt2: float,
+    dt2: Float,
 ):
     """
     Args:
@@ -450,7 +450,7 @@ def update_y_velocity(
     cosa: FloatFieldIJ,
     sina: FloatFieldIJ,
     rdyc: FloatFieldIJ,
-    dt2: float,
+    dt2: Float,
 ):
     """
     Args:
@@ -631,7 +631,7 @@ class CGridShallowWaterDynamics:
         vt: FloatField,
         divgd: FloatField,
         omga: FloatField,
-        dt2: float,
+        dt2: Float,
     ):
         """
         C-grid shallow water routine.

--- a/fv3core/pace/fv3core/stencils/d2a2c_vect.py
+++ b/fv3core/pace/fv3core/stencils/d2a2c_vect.py
@@ -4,7 +4,7 @@ from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils.a2b_ord4 import a1, a2, lagrange_x_func, lagrange_y_func
 from pace.stencils import corners
 from pace.util import X_DIM, Y_DIM, Z_DIM
@@ -422,12 +422,12 @@ class DGrid2AGrid2CGridVectors:
         self._utmp = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m/s",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._vtmp = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m/s",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         js1 = npt + OFFSET if grid_indexing.south_edge else grid_indexing.jsc - 1

--- a/fv3core/pace/fv3core/stencils/d2a2c_vect.py
+++ b/fv3core/pace/fv3core/stencils/d2a2c_vect.py
@@ -17,7 +17,7 @@ c3 = 5.0 / 14.0
 OFFSET = 2
 
 
-def set_tmps(utmp: FloatField, vtmp: FloatField, big_number: float):
+def set_tmps(utmp: FloatField, vtmp: FloatField, big_number: Float):
     with computation(PARALLEL), interval(...):
         utmp = big_number
         vtmp = big_number

--- a/fv3core/pace/fv3core/stencils/d2a2c_vect.py
+++ b/fv3core/pace/fv3core/stencils/d2a2c_vect.py
@@ -419,8 +419,16 @@ class DGrid2AGrid2CGridVectors:
         npt = 4 if not nested else 0
         if npt > grid_indexing.domain[0] - 1 or npt > grid_indexing.domain[1] - 1:
             npt = 0
-        self._utmp = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m/s")
-        self._vtmp = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m/s")
+        self._utmp = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m/s",
+            dtype=pace.util.pfloat(),
+        )
+        self._vtmp = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m/s",
+            dtype=pace.util.pfloat(),
+        )
 
         js1 = npt + OFFSET if grid_indexing.south_edge else grid_indexing.jsc - 1
         je1 = ny - npt if grid_indexing.north_edge else grid_indexing.jec + 1

--- a/fv3core/pace/fv3core/stencils/d_sw.py
+++ b/fv3core/pace/fv3core/stencils/d_sw.py
@@ -70,7 +70,7 @@ def heat_diss(
     dw: FloatField,
     damp_w: FloatFieldK,
     ke_bg: FloatFieldK,
-    dt: float,
+    dt: Float,
 ):
     """
     Calculate heat generation due to loss of kinetic energy
@@ -217,7 +217,7 @@ def compute_kinetic_energy(
     dya: FloatFieldIJ,
     rdy: FloatFieldIJ,
     dt_kinetic_energy_on_cell_corners: FloatField,
-    dt: float,
+    dt: Float,
 ):
     """
     Args:

--- a/fv3core/pace/fv3core/stencils/d_sw.py
+++ b/fv3core/pace/fv3core/stencils/d_sw.py
@@ -14,7 +14,7 @@ import pace.fv3core.stencils.delnflux as delnflux
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from pace.fv3core._config import DGridShallowWaterLagrangianDynamicsConfig
 from pace.fv3core.stencils.d2a2c_vect import contravariant
 from pace.fv3core.stencils.delnflux import DelnFluxNoSG
@@ -655,7 +655,7 @@ def get_column_namelist(
         col[name] = quantity_factory.zeros(
             dims=[Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
     for name in direct_namelist:
         col[name].view[:] = getattr(config, name)
@@ -767,7 +767,7 @@ class DGridShallowWaterLagrangianDynamics:
             return quantity_factory.zeros(
                 [X_DIM, Y_DIM, Z_DIM],
                 units="unknown",
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
 
         self._tmp_heat_s = make_quantity()

--- a/fv3core/pace/fv3core/stencils/d_sw.py
+++ b/fv3core/pace/fv3core/stencils/d_sw.py
@@ -652,7 +652,11 @@ def get_column_namelist(
     col: Dict[str, pace.util.Quantity] = {}
     for name in all_names:
         # TODO: fill units information
-        col[name] = quantity_factory.zeros(dims=[Z_DIM], units="unknown")
+        col[name] = quantity_factory.zeros(
+            dims=[Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
     for name in direct_namelist:
         col[name].view[:] = getattr(config, name)
 
@@ -760,7 +764,11 @@ class DGridShallowWaterLagrangianDynamics:
         self.hydrostatic = config.hydrostatic
 
         def make_quantity():
-            return quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros(
+                [X_DIM, Y_DIM, Z_DIM],
+                units="unknown",
+                dtype=pace.util.pfloat(),
+            )
 
         self._tmp_heat_s = make_quantity()
         self._vort_x_delta = make_quantity()

--- a/fv3core/pace/fv3core/stencils/del2cubed.py
+++ b/fv3core/pace/fv3core/stencils/del2cubed.py
@@ -101,12 +101,20 @@ class HyperdiffusionDamping:
         # the units of these temporaries are relative to the input units,
         # so they are undefined
         self._fx = quantity_factory.zeros(
-            dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM], units="undefined"
+            dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM],
+            units="undefined",
+            dtype=pace.util.pfloat(),
         )
         self._fy = quantity_factory.zeros(
-            dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM], units="undefined"
+            dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM],
+            units="undefined",
+            dtype=pace.util.pfloat(),
         )
-        self._q = quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="undefined")
+        self._q = quantity_factory.zeros(
+            dims=[X_DIM, Y_DIM, Z_DIM],
+            units="undefined",
+            dtype=pace.util.pfloat(),
+        )
 
         self._corner_fill = stencil_factory.from_dims_halo(
             func=corner_fill,

--- a/fv3core/pace/fv3core/stencils/del2cubed.py
+++ b/fv3core/pace/fv3core/stencils/del2cubed.py
@@ -69,7 +69,7 @@ def corner_fill(q_in: FloatField, q_out: FloatField):
 # Q update stencil
 # ------------------
 def update_q(
-    q: FloatField, rarea: FloatFieldIJ, fx: FloatField, fy: FloatField, cd: float
+    q: FloatField, rarea: FloatFieldIJ, fx: FloatField, fy: FloatField, cd: Float
 ):
     with computation(PARALLEL), interval(...):
         q += cd * rarea * (fx - fx[1, 0, 0] + fy - fy[0, 1, 0])
@@ -170,7 +170,7 @@ class HyperdiffusionDamping:
             update_q, origins, domains, stencil_factory=stencil_factory
         )
 
-    def __call__(self, qdel: FloatField, cd: float):
+    def __call__(self, qdel: FloatField, cd: Float):
         """
         Perform hyperdiffusion damping/filtering.
 

--- a/fv3core/pace/fv3core/stencils/del2cubed.py
+++ b/fv3core/pace/fv3core/stencils/del2cubed.py
@@ -4,7 +4,7 @@ import pace.stencils.corners as corners
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory, get_stencils_with_varied_bounds
-from pace.dsl.typing import FloatField, FloatFieldIJ, cast_to_index3d
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, cast_to_index3d
 from pace.fv3core.stencils.basic_operations import copy_defn
 from pace.util import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from pace.util.grid import DampingCoefficients
@@ -103,17 +103,17 @@ class HyperdiffusionDamping:
         self._fx = quantity_factory.zeros(
             dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM],
             units="undefined",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._fy = quantity_factory.zeros(
             dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM],
             units="undefined",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._q = quantity_factory.zeros(
             dims=[X_DIM, Y_DIM, Z_DIM],
             units="undefined",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         self._corner_fill = stencil_factory.from_dims_halo(

--- a/fv3core/pace/fv3core/stencils/delnflux.py
+++ b/fv3core/pace/fv3core/stencils/delnflux.py
@@ -1139,10 +1139,10 @@ class DelnFluxNoSG:
             domains_fy.append((nt_nx - 2, nt_ny - 1, nk))
 
         nord_dictionary = {
-            "nord0": Float(nord.view[0]),
-            "nord1": Float(nord.view[1]),
-            "nord2": Float(nord.view[2]),
-            "nord3": Float(nord.view[3]),
+            "nord0": nord.view[0],
+            "nord1": nord.view[1],
+            "nord2": nord.view[2],
+            "nord3": nord.view[3],
         }
 
         self._d2_damp = stencil_factory.from_origin_domain(

--- a/fv3core/pace/fv3core/stencils/delnflux.py
+++ b/fv3core/pace/fv3core/stencils/delnflux.py
@@ -982,9 +982,21 @@ class DelnFlux:
         nk = grid_indexing.domain[2]
         self._origin = grid_indexing.origin_full()
 
-        self._fx2 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="undefined")
-        self._fy2 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="undefined")
-        self._d2 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="undefined")
+        self._fx2 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="undefined",
+            dtype=pace.util.pfloat(),
+        )
+        self._fy2 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="undefined",
+            dtype=pace.util.pfloat(),
+        )
+        self._d2 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="undefined",
+            dtype=pace.util.pfloat(),
+        )
 
         self._add_diffusive_stencil = stencil_factory.from_dims_halo(
             func=add_diffusive_component,

--- a/fv3core/pace/fv3core/stencils/delnflux.py
+++ b/fv3core/pace/fv3core/stencils/delnflux.py
@@ -1139,11 +1139,15 @@ class DelnFluxNoSG:
             domains_fy.append((nt_nx - 2, nt_ny - 1, nk))
 
         nord_dictionary = {
-            "nord0": nord.view[0],
-            "nord1": nord.view[1],
-            "nord2": nord.view[2],
-            "nord3": nord.view[3],
+            "nord0": float(nord.view[0]),
+            "nord1": float(nord.view[1]),
+            "nord2": float(nord.view[2]),
+            "nord3": float(nord.view[3]),
         }
+        nord_dictionary["nord0"] = Float(nord_dictionary["nord0"])
+        nord_dictionary["nord1"] = Float(nord_dictionary["nord1"])
+        nord_dictionary["nord2"] = Float(nord_dictionary["nord2"])
+        nord_dictionary["nord3"] = Float(nord_dictionary["nord3"])
 
         self._d2_damp = stencil_factory.from_origin_domain(
             d2_damp_interval,

--- a/fv3core/pace/fv3core/stencils/delnflux.py
+++ b/fv3core/pace/fv3core/stencils/delnflux.py
@@ -13,7 +13,7 @@ from gt4py.cartesian.gtscript import (
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory, get_stencils_with_varied_bounds
-from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from pace.util import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from pace.util.grid import DampingCoefficients
 
@@ -985,17 +985,17 @@ class DelnFlux:
         self._fx2 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="undefined",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._fy2 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="undefined",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._d2 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="undefined",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         self._add_diffusive_stencil = stencil_factory.from_dims_halo(

--- a/fv3core/pace/fv3core/stencils/delnflux.py
+++ b/fv3core/pace/fv3core/stencils/delnflux.py
@@ -19,7 +19,7 @@ from pace.util.grid import DampingCoefficients
 
 
 def calc_damp(
-    damp_c: pace.util.Quantity, da_min: float, nord: pace.util.Quantity
+    damp_c: pace.util.Quantity, da_min: Float, nord: pace.util.Quantity
 ) -> pace.util.Quantity:
     if damp_c.dims != nord.dims or damp_c.data.shape != nord.data.shape:
         raise NotImplementedError(
@@ -1139,10 +1139,10 @@ class DelnFluxNoSG:
             domains_fy.append((nt_nx - 2, nt_ny - 1, nk))
 
         nord_dictionary = {
-            "nord0": float(nord.view[0]),
-            "nord1": float(nord.view[1]),
-            "nord2": float(nord.view[2]),
-            "nord3": float(nord.view[3]),
+            "nord0": Float(nord.view[0]),
+            "nord1": Float(nord.view[1]),
+            "nord2": Float(nord.view[2]),
+            "nord3": Float(nord.view[3]),
         }
 
         self._d2_damp = stencil_factory.from_origin_domain(

--- a/fv3core/pace/fv3core/stencils/divergence_damping.py
+++ b/fv3core/pace/fv3core/stencils/divergence_damping.py
@@ -13,7 +13,7 @@ import pace.stencils.corners as corners
 import pace.util
 from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.stencil import StencilFactory, get_stencils_with_varied_bounds
-from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from pace.fv3core.stencils.a2b_ord4 import AGrid2BGridFourthOrder
 from pace.fv3core.stencils.d2a2c_vect import contravariant
 from pace.util import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
@@ -140,9 +140,9 @@ def damping(
     vort: FloatField,
     ke: FloatField,
     d2_bg: FloatFieldK,
-    da_min_c: float,
-    dddmp: float,
-    dt: float,
+    da_min_c: Float,
+    dddmp: Float,
+    dt: Float,
 ):
     """
     Args:
@@ -164,9 +164,9 @@ def damping_nord_highorder_stencil(
     delpc: FloatField,
     divg_d: FloatField,
     d2_bg: FloatFieldK,
-    da_min_c: float,
-    dddmp: float,
-    dd8: float,
+    da_min_c: Float,
+    dddmp: Float,
+    dd8: Float,
 ):
     """
     Args:
@@ -240,7 +240,7 @@ def redo_divg_d(
             divg_d = divg_d * adjustment_factor
 
 
-def smagorinsky_diffusion_approx(delpc: FloatField, vort: FloatField, absdt: float):
+def smagorinsky_diffusion_approx(delpc: FloatField, vort: FloatField, absdt: Float):
     """
     Args:
         delpc (in): divergence on cell corners
@@ -351,12 +351,12 @@ class DivergenceDamping:
         self.u_contra_dyc = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m^2/s",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self.v_contra_dxc = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m^2/s",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         self._damping = low_k_stencil_factory.from_dims_halo(
@@ -500,7 +500,7 @@ class DivergenceDamping:
         delpc: FloatField,
         ke: FloatField,
         rel_vort_agrid: FloatField,
-        dt: float,
+        dt: Float,
     ):
         """
         Adds another form of diffusive flux that acts on the divergence field.
@@ -573,7 +573,7 @@ class DivergenceDamping:
                 self.v_contra_dxc,
             )
 
-            da_min_c: float = self._get_da_min_c()
+            da_min_c: Float = self._get_da_min_c()
             self._damping(
                 delpc,
                 damped_rel_vort_bgrid,
@@ -621,7 +621,7 @@ class DivergenceDamping:
                 abs(dt),
             )
 
-        da_min: float = self._get_da_min()
+        da_min: Float = self._get_da_min()
         if self._stretched_grid:
             # reference https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/blob/main/model/sw_core.F90#L1422 # noqa: E501
             dd8 = da_min * self._d4_bg ** (self._nonzero_nord + 1)

--- a/fv3core/pace/fv3core/stencils/divergence_damping.py
+++ b/fv3core/pace/fv3core/stencils/divergence_damping.py
@@ -348,8 +348,16 @@ class DivergenceDamping:
             compute_halos=(0, 0),
         )
 
-        self.u_contra_dyc = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m^2/s")
-        self.v_contra_dxc = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m^2/s")
+        self.u_contra_dyc = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m^2/s",
+            dtype=pace.util.pfloat(),
+        )
+        self.v_contra_dxc = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m^2/s",
+            dtype=pace.util.pfloat(),
+        )
 
         self._damping = low_k_stencil_factory.from_dims_halo(
             damping,

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -26,7 +26,7 @@ import pace.util.constants as constants
 from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.dace.wrapped_halo_exchange import WrappedHaloUpdater
 from pace.dsl.stencil import GridIndexing, StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core._config import AcousticDynamicsConfig
 from pace.fv3core.initialization.dycore_state import DycoreState
 from pace.fv3core.stencils.c_sw import CGridShallowWaterDynamics
@@ -199,35 +199,35 @@ def dyncore_temporaries(
         temporaries[name] = quantity_factory.zeros(
             dims=[X_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
     for name in ["gz", "pkc", "zh"]:
         temporaries[name] = quantity_factory.zeros(
             dims=[X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
     temporaries["divgd"] = quantity_factory.zeros(
         dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM],
         units="unknown",
-        dtype=pace.util.pfloat(),
+        dtype=Float,
     )
     temporaries["ws3"] = quantity_factory.zeros(
         dims=[X_DIM, Y_DIM],
         units="unknown",
-        dtype=pace.util.pfloat(),
+        dtype=Float,
     )
     for name in ["crx", "xfx"]:
         temporaries[name] = quantity_factory.zeros(
             dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
     for name in ["cry", "yfx"]:
         temporaries[name] = quantity_factory.zeros(
             dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
     return temporaries
 
@@ -259,27 +259,27 @@ class AcousticDynamics:
             full_size_xyz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
             full_size_xyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
             full_size_xiyz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_INTERFACE_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
             full_size_xyzi_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_INTERFACE_DIM],
                 n_halo=grid_indexing.n_halo,
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
             full_size_xiyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
 
             # Build the HaloUpdater. We could build one updater per specification group
@@ -341,7 +341,7 @@ class AcousticDynamics:
                 full_3Dfield_2pts_halo_spec = quantity_factory.get_quantity_halo_spec(
                     dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_INTERFACE_DIM],
                     n_halo=2,
-                    dtype=pace.util.pfloat(),
+                    dtype=Float,
                 )
                 self.pkc = WrappedHaloUpdater(
                     comm.get_scalar_halo_updater([full_3Dfield_2pts_halo_spec]),
@@ -480,9 +480,11 @@ class AcousticDynamics:
             self._zs = quantity_factory.zeros(
                 [X_DIM, Y_DIM],
                 units="m",
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
-            self._zs.data[:] = self._zs.np.asarray(phis.data / constants.GRAV)
+            self._zs.data[:] = self._zs.np.asarray(
+                phis.data / constants.GRAV, dtype=self._zs.data.dtype
+            )
 
             self.update_height_on_d_grid = updatedzd.UpdateHeightOnDGrid(
                 stencil_factory,

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -197,23 +197,37 @@ def dyncore_temporaries(
         # TODO: the dimensions of ut and vt may not be correct,
         #       because they are not used. double-check and correct as needed.
         temporaries[name] = quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM, Z_DIM], units="unknown"
+            dims=[X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
     for name in ["gz", "pkc", "zh"]:
         temporaries[name] = quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM, Z_INTERFACE_DIM], units="unknown"
+            dims=[X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
     temporaries["divgd"] = quantity_factory.zeros(
-        dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM], units="unknown"
+        dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM],
+        units="unknown",
+        dtype=pace.util.pfloat(),
     )
-    temporaries["ws3"] = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
+    temporaries["ws3"] = quantity_factory.zeros(
+        dims=[X_DIM, Y_DIM],
+        units="unknown",
+        dtype=pace.util.pfloat(),
+    )
     for name in ["crx", "xfx"]:
         temporaries[name] = quantity_factory.zeros(
-            dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM], units="unknown"
+            dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
     for name in ["cry", "yfx"]:
         temporaries[name] = quantity_factory.zeros(
-            dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM], units="unknown"
+            dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
     return temporaries
 
@@ -245,22 +259,27 @@ class AcousticDynamics:
             full_size_xyz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
+                dtype=pace.util.pfloat(),
             )
             full_size_xyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
+                dtype=pace.util.pfloat(),
             )
             full_size_xiyz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_INTERFACE_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
+                dtype=pace.util.pfloat(),
             )
             full_size_xyzi_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_INTERFACE_DIM],
                 n_halo=grid_indexing.n_halo,
+                dtype=pace.util.pfloat(),
             )
             full_size_xiyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
+                dtype=pace.util.pfloat(),
             )
 
             # Build the HaloUpdater. We could build one updater per specification group
@@ -322,6 +341,7 @@ class AcousticDynamics:
                 full_3Dfield_2pts_halo_spec = quantity_factory.get_quantity_halo_spec(
                     dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_INTERFACE_DIM],
                     n_halo=2,
+                    dtype=pace.util.pfloat(),
                 )
                 self.pkc = WrappedHaloUpdater(
                     comm.get_scalar_halo_updater([full_3Dfield_2pts_halo_spec]),
@@ -457,7 +477,11 @@ class AcousticDynamics:
             # To write lower dimensional storages, these need to be 3D
             # then converted to lower dimensional
             self._dp_ref = grid_data.dp_ref
-            self._zs = quantity_factory.zeros([X_DIM, Y_DIM], units="m")
+            self._zs = quantity_factory.zeros(
+                [X_DIM, Y_DIM],
+                units="m",
+                dtype=pace.util.pfloat(),
+            )
             self._zs.data[:] = self._zs.np.asarray(phis.data / constants.GRAV)
 
             self.update_height_on_d_grid = updatedzd.UpdateHeightOnDGrid(

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -97,7 +97,7 @@ def gz_from_surface_height_and_thicknesses(
 
 
 def interface_pressure_from_toa_pressure_and_thickness(
-    delp: FloatField, pem: FloatField, ptop: float
+    delp: FloatField, pem: FloatField, ptop: Float
 ):
     """
     Args:
@@ -125,7 +125,7 @@ def p_grad_c_stencil(
     delpc: FloatField,
     pkc: FloatField,
     gz: FloatField,
-    dt2: float,
+    dt2: Float,
 ):
     """
     Update C-grid winds from the backwards-in-time pressure gradient force
@@ -696,7 +696,7 @@ class AcousticDynamics:
     def __call__(
         self,
         state: DycoreState,
-        timestep: float,  # time to step forward by in seconds
+        timestep: Float,  # time to step forward by in seconds
         n_map=1,  # [DaCe] replaces state.n_map
     ):
         # u, v, w, delz, delp, pt, pe, pk, phis, wsd, omga, ua, va, uc, vc, mfxd,
@@ -975,7 +975,7 @@ class AcousticDynamics:
         if self._do_del2cubed:
             self._halo_updaters.heat_source.update()
             # TODO: move dependence on da_min into init of hyperdiffusion class
-            da_min: float = self._get_da_min()
+            da_min: Float = self._get_da_min()
             cd = constants.CNST_0P20 * da_min
             # we want to diffuse the heat source from damping before we apply it,
             # so that we don't reinforce the same grid-scale patterns we're trying

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -703,10 +703,10 @@ class AcousticDynamics:
         # mfyd, cxd, cyd, pkz, peln, q_con, ak, bk, diss_estd, cappa, mdt, n_split,
         # akap, ptop, n_map, comm):
         end_step = n_map == self.config.k_split
-        akap = constants.KAPPA
+        akap = Float(constants.KAPPA)
         # dt = state.mdt / self.config.n_split
         dt_acoustic_substep = timestep / self.config.n_split
-        dt2 = 0.5 * dt_acoustic_substep
+        dt2 = Float(0.5) * dt_acoustic_substep
         n_split = self.config.n_split
         # NOTE: In Fortran model the halo update starts happens in fv_dynamics, not here
         self._halo_updaters.q_con__cappa.start()

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -449,6 +449,7 @@ class AcousticDynamics:
                 grid_type=config.grid_type,
             )
         )
+        self._akap = Float(constants.KAPPA)
 
         temporaries = dyncore_temporaries(quantity_factory)
         self._heat_source = temporaries["heat_source"]
@@ -703,10 +704,9 @@ class AcousticDynamics:
         # mfyd, cxd, cyd, pkz, peln, q_con, ak, bk, diss_estd, cappa, mdt, n_split,
         # akap, ptop, n_map, comm):
         end_step = n_map == self.config.k_split
-        akap = Float(constants.KAPPA)
         # dt = state.mdt / self.config.n_split
         dt_acoustic_substep = timestep / self.config.n_split
-        dt2 = Float(0.5) * dt_acoustic_substep
+        dt2 = 0.5 * dt_acoustic_substep
         n_split = self.config.n_split
         # NOTE: In Fortran model the halo update starts happens in fv_dynamics, not here
         self._halo_updaters.q_con__cappa.start()
@@ -927,7 +927,7 @@ class AcousticDynamics:
                         "unimplemented namelist option use_logp=True"
                     )
                 else:
-                    self._pk3_halo(self._pk3, state.delp, self._ptop, akap)
+                    self._pk3_halo(self._pk3, state.delp, self._ptop, self._akap)
             if not self.config.hydrostatic:
                 self._halo_updaters.zh.wait()
                 self._compute_geopotential_stencil(
@@ -945,7 +945,7 @@ class AcousticDynamics:
                     state.delp,
                     dt_acoustic_substep,
                     self._ptop,
-                    akap,
+                    self._akap,
                 )
 
             if self.config.rf_fast:

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -694,6 +694,17 @@ class AcousticDynamics:
                 mfyd=state.mfyd,
             )
 
+    # TODO: fix me - we shouldn't need a function here, Dace is fudging the types
+    # See https://github.com/GEOS-ESM/pace/issues/9
+    @dace_inhibitor
+    def dt_acoustic_substep(self, timestep: Float) -> Float:
+        return timestep / self.config.n_split
+
+    # TODO: Same as above
+    @dace_inhibitor
+    def dt2(self, dt_acoustic_substep: Float) -> Float:
+        return 0.5 * dt_acoustic_substep
+
     def __call__(
         self,
         state: DycoreState,
@@ -705,8 +716,8 @@ class AcousticDynamics:
         # akap, ptop, n_map, comm):
         end_step = n_map == self.config.k_split
         # dt = state.mdt / self.config.n_split
-        dt_acoustic_substep = timestep / self.config.n_split
-        dt2 = 0.5 * dt_acoustic_substep
+        dt_acoustic_substep: Float = self.dt_acoustic_substep(timestep)
+        dt2: Float = self.dt2(dt_acoustic_substep)
         n_split = self.config.n_split
         # NOTE: In Fortran model the halo update starts happens in fv_dynamics, not here
         self._halo_updaters.q_con__cappa.start()

--- a/fv3core/pace/fv3core/stencils/fillz.py
+++ b/fv3core/pace/fv3core/stencils/fillz.py
@@ -7,7 +7,7 @@ import pace.dsl.gt4py_utils as utils
 import pace.util
 from pace.dsl.dace import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ, IntFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ
 from pace.util import X_DIM, Y_DIM, Z_DIM
 
 
@@ -139,12 +139,12 @@ class FillNegativeTracerValues:
         self._sum0 = quantity_factory.zeros(
             [X_DIM, Y_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._sum1 = quantity_factory.zeros(
             [X_DIM, Y_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         self._filtered_tracer_dict = {

--- a/fv3core/pace/fv3core/stencils/fillz.py
+++ b/fv3core/pace/fv3core/stencils/fillz.py
@@ -136,8 +136,16 @@ class FillNegativeTracerValues:
         # Setting initial value of upper_fix to zero is only needed for validation.
         # The values in the compute domain are set to zero in the stencil.
         self._zfix = quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=int)
-        self._sum0 = quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
-        self._sum1 = quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
+        self._sum0 = quantity_factory.zeros(
+            [X_DIM, Y_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
+        self._sum1 = quantity_factory.zeros(
+            [X_DIM, Y_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
 
         self._filtered_tracer_dict = {
             name: tracers[name] for name in utils.tracer_variables[0 : self._nq]

--- a/fv3core/pace/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/pace/fv3core/stencils/fv_dynamics.py
@@ -580,7 +580,7 @@ class DynamicalCore:
                 # TODO: can we pull this block out of the loop intead of
                 # using an if-statement?
                 if last_step:
-                    da_min: float = self._get_da_min()
+                    da_min: Float = self._get_da_min()
                     if not self.config.hydrostatic:
                         if __debug__:
                             log_on_rank_0("Omega")

--- a/fv3core/pace/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/pace/fv3core/stencils/fv_dynamics.py
@@ -70,13 +70,16 @@ def fvdyn_temporaries(
     tmps = {}
     for name in ["te_2d", "te0_2d", "wsd"]:
         quantity = quantity_factory.zeros(
-            dims=[pace.util.X_DIM, pace.util.Y_DIM], units="unknown"
+            dims=[pace.util.X_DIM, pace.util.Y_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
         tmps[name] = quantity
     for name in ["dp1", "cvm"]:
         quantity = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             units="unknown",
+            dtype=pace.util.pfloat(),
         )
         tmps[name] = quantity
     return tmps
@@ -304,6 +307,7 @@ class DynamicalCore:
         full_xyz_spec = quantity_factory.get_quantity_halo_spec(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             n_halo=grid_indexing.n_halo,
+            dtype=pace.util.pfloat(),
         )
         self._omega_halo_updater = WrappedHaloUpdater(
             comm.get_scalar_halo_updater([full_xyz_spec]), state, ["omga"], comm=comm

--- a/fv3core/pace/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/pace/fv3core/stencils/fv_dynamics.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import timedelta
 from typing import Mapping, Optional
 
@@ -24,10 +23,9 @@ from pace.fv3core.stencils.remapping import LagrangianToEulerian
 from pace.stencils.c2l_ord import CubedToLatLon
 from pace.util import X_DIM, Y_DIM, Z_INTERFACE_DIM, Timer
 from pace.util.grid import DampingCoefficients, GridData
+from pace.util.logging import pace_log
 from pace.util.mpi import MPI
 
-
-logger = logging.getLogger(__name__)
 
 # nq is actually given by ncnst - pnats, where those are given in atmosphere.F90 by:
 # ncnst = Atm(mytile)%ncnst
@@ -89,7 +87,7 @@ def fvdyn_temporaries(
 def log_on_rank_0(msg: str):
     """Print when rank is 0 - outside of DaCe critical path"""
     if not MPI or MPI.COMM_WORLD.Get_rank() == 0:
-        logger.info(msg)
+        pace_log.info(msg)
 
 
 class DynamicalCore:

--- a/fv3core/pace/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/pace/fv3core/stencils/fv_dynamics.py
@@ -12,7 +12,7 @@ import pace.util.constants as constants
 from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.dace.wrapped_halo_exchange import WrappedHaloUpdater
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField
+from pace.dsl.typing import Float, FloatField
 from pace.fv3core._config import DynamicalCoreConfig
 from pace.fv3core.initialization.dycore_state import DycoreState
 from pace.fv3core.stencils import fvtp2d, tracer_2d_1l
@@ -72,14 +72,14 @@ def fvdyn_temporaries(
         quantity = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         tmps[name] = quantity
     for name in ["dp1", "cvm"]:
         quantity = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         tmps[name] = quantity
     return tmps
@@ -307,7 +307,7 @@ class DynamicalCore:
         full_xyz_spec = quantity_factory.get_quantity_halo_spec(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             n_halo=grid_indexing.n_halo,
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._omega_halo_updater = WrappedHaloUpdater(
             comm.get_scalar_halo_updater([full_xyz_spec]), state, ["omga"], comm=comm

--- a/fv3core/pace/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/pace/fv3core/stencils/fv_subgridz.py
@@ -13,7 +13,7 @@ from gt4py.cartesian.gtscript import (
 import pace.dsl.gt4py_utils as utils
 import pace.util
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField
+from pace.dsl.typing import Float, FloatField
 from pace.fv3core.initialization.dycore_state import DycoreState
 from pace.fv3core.stencils.basic_operations import dim
 from pace.util import X_DIM, Y_DIM, Z_DIM
@@ -249,8 +249,8 @@ def m_loop(
     total_energy: FloatField,
     cpm: FloatField,
     cvm: FloatField,
-    t_min: float,
-    ratio: float,
+    t_min: Float,
+    ratio: Float,
 ):
     from __externals__ import t_max, xvir
 
@@ -693,7 +693,7 @@ def finalize(
     qo3mr: FloatField,
     qsgs_tke: FloatField,
     qcld: FloatField,
-    timestep: float,
+    timestep: Float,
 ):
     from __externals__ import fv_sg_adj, hydrostatic
 

--- a/fv3core/pace/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/pace/fv3core/stencils/fv_subgridz.py
@@ -779,7 +779,7 @@ class DryConvectiveAdjustment:
         stencil_factory: StencilFactory,
         quantity_factory: pace.util.QuantityFactory,
         nwat: int,
-        fv_sg_adj: float,
+        fv_sg_adj: Float,
         n_sponge: int,
         hydrostatic: bool,
     ):
@@ -853,7 +853,7 @@ class DryConvectiveAdjustment:
         state: DycoreState,
         u_dt: pace.util.Quantity,
         v_dt: pace.util.Quantity,
-        timestep: float,
+        timestep: Float,
     ):
         """
         Performs dry convective adjustment mixing on the subgrid vertical scale.

--- a/fv3core/pace/fv3core/stencils/fvtp2d.py
+++ b/fv3core/pace/fv3core/stencils/fvtp2d.py
@@ -148,7 +148,11 @@ class FiniteVolumeTransport:
         origin = idx.origin_compute()
 
         def make_quantity():
-            return quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros(
+                [X_DIM, Y_DIM, Z_DIM],
+                units="unknown",
+                dtype=pace.util.pfloat(),
+            )
 
         self._q_advected_y = make_quantity()
         self._q_advected_x = make_quantity()

--- a/fv3core/pace/fv3core/stencils/fvtp2d.py
+++ b/fv3core/pace/fv3core/stencils/fvtp2d.py
@@ -7,7 +7,7 @@ import pace.stencils.corners as corners
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils.delnflux import DelnFlux
 from pace.fv3core.stencils.xppm import XPiecewiseParabolic
 from pace.fv3core.stencils.yppm import YPiecewiseParabolic
@@ -151,7 +151,7 @@ class FiniteVolumeTransport:
             return quantity_factory.zeros(
                 [X_DIM, Y_DIM, Z_DIM],
                 units="unknown",
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
 
         self._q_advected_y = make_quantity()

--- a/fv3core/pace/fv3core/stencils/fxadv.py
+++ b/fv3core/pace/fv3core/stencils/fxadv.py
@@ -2,7 +2,7 @@ from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval
 
 from pace.dsl.dace import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils.d2a2c_vect import contravariant
 from pace.util.grid import GridData
 
@@ -419,7 +419,7 @@ def fxadv_stencil(
     vc: FloatField,
     ut: FloatField,
     vt: FloatField,
-    dt: float,
+    dt: Float,
 ):
     with computation(PARALLEL), interval(...):
         ut = main_ut(uc, vc, cosa_u, rsin_u, ut)
@@ -448,7 +448,7 @@ def fxadv_fluxes_stencil(
     y_area_flux: FloatField,
     uc_contra: FloatField,
     vc_contra: FloatField,
-    dt: float,
+    dt: Float,
 ):
     """
     Args:

--- a/fv3core/pace/fv3core/stencils/map_single.py
+++ b/fv3core/pace/fv3core/stencils/map_single.py
@@ -158,7 +158,7 @@ class MapSingle:
         pe1: FloatField,
         pe2: FloatField,
         qs: Optional["FloatFieldIJ"] = None,
-        qmin: float = 0.0,
+        qmin: Float = 0.0,
     ):
         """
         Compute x-flux using the PPM method.

--- a/fv3core/pace/fv3core/stencils/map_single.py
+++ b/fv3core/pace/fv3core/stencils/map_single.py
@@ -5,7 +5,7 @@ from gt4py.cartesian.gtscript import FORWARD, PARALLEL, computation, interval
 import pace.util
 from pace.dsl.dace import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ, IntFieldIJ  # noqa: F401
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ  # noqa: F401
 from pace.fv3core.stencils.basic_operations import copy_defn
 from pace.fv3core.stencils.remap_profile import RemapProfile
 from pace.util import X_DIM, Y_DIM, Z_DIM
@@ -106,7 +106,7 @@ class MapSingle:
             return quantity_factory.zeros(
                 [X_DIM, Y_DIM, Z_DIM],
                 units="unknown",
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
 
         self._dp1 = make_quantity()
@@ -117,7 +117,7 @@ class MapSingle:
         self._tmp_qs = quantity_factory.zeros(
             [X_DIM, Y_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._lev = quantity_factory.zeros([X_DIM, Y_DIM], units="", dtype=int)
 

--- a/fv3core/pace/fv3core/stencils/map_single.py
+++ b/fv3core/pace/fv3core/stencils/map_single.py
@@ -103,14 +103,22 @@ class MapSingle:
         grid_indexing = stencil_factory.grid_indexing
 
         def make_quantity():
-            return quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros(
+                [X_DIM, Y_DIM, Z_DIM],
+                units="unknown",
+                dtype=pace.util.pfloat(),
+            )
 
         self._dp1 = make_quantity()
         self._q4_1 = make_quantity()
         self._q4_2 = make_quantity()
         self._q4_3 = make_quantity()
         self._q4_4 = make_quantity()
-        self._tmp_qs = quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
+        self._tmp_qs = quantity_factory.zeros(
+            [X_DIM, Y_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
         self._lev = quantity_factory.zeros([X_DIM, Y_DIM], units="", dtype=int)
 
         self._copy_stencil = stencil_factory.from_dims_halo(

--- a/fv3core/pace/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/pace/fv3core/stencils/mapn_tracer.py
@@ -4,7 +4,7 @@ import pace.dsl.gt4py_utils as utils
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField
+from pace.dsl.typing import Float, FloatField
 from pace.fv3core.stencils.fillz import FillNegativeTracerValues
 from pace.fv3core.stencils.map_single import MapSingle
 from pace.util import X_DIM, Y_DIM, Z_DIM
@@ -33,7 +33,7 @@ class MapNTracer:
         self._qs = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         kord_tracer = [kord] * self._nq

--- a/fv3core/pace/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/pace/fv3core/stencils/mapn_tracer.py
@@ -30,7 +30,11 @@ class MapNTracer:
             dace_compiletime_args=["tracers"],
         )
         self._nq = int(nq)
-        self._qs = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+        self._qs = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
 
         kord_tracer = [kord] * self._nq
         kord_tracer[5] = 9  # qcld

--- a/fv3core/pace/fv3core/stencils/moist_cv.py
+++ b/fv3core/pace/fv3core/stencils/moist_cv.py
@@ -9,7 +9,7 @@ from gt4py.cartesian.gtscript import (
 )
 
 import pace.util.constants as constants
-from pace.dsl.typing import FloatField
+from pace.dsl.typing import Float, FloatField
 
 
 @gtscript.function
@@ -58,7 +58,7 @@ def moist_pt_func(
     cappa: FloatField,
     delp: FloatField,
     delz: FloatField,
-    r_vir: float,
+    r_vir: Float,
 ):
     cvm, gz = moist_cv_nwat6_fn(
         qvapor, qliquid, qrain, qsnow, qice, qgraupel
@@ -72,11 +72,11 @@ def moist_pt_func(
 @gtscript.function
 def last_pt(
     pt: FloatField,
-    dtmp: float,
+    dtmp: Float,
     pkz: FloatField,
     gz: FloatField,
     qv: FloatField,
-    zvir: float,
+    zvir: Float,
 ):
     return (pt + dtmp * pkz) / ((1.0 + zvir * qv) * (1.0 - gz))
 
@@ -91,8 +91,8 @@ def moist_pt_last_step(
     gz: FloatField,
     pt: FloatField,
     pkz: FloatField,
-    dtmp: float,
-    r_vir: float,
+    dtmp: Float,
+    r_vir: Float,
 ):
     """
     Args:
@@ -142,7 +142,7 @@ def moist_pkz(
     cappa: FloatField,
     delp: FloatField,
     delz: FloatField,
-    r_vir: float,
+    r_vir: Float,
 ):
     """
     Args:

--- a/fv3core/pace/fv3core/stencils/neg_adj3.py
+++ b/fv3core/pace/fv3core/stencils/neg_adj3.py
@@ -100,8 +100,8 @@ def fix_neg_water(
     qsnow: FloatField,
     qice: FloatField,
     qgraupel: FloatField,
-    lv00: float,
-    d0_vap: float,
+    lv00: Float,
+    d0_vap: Float,
 ):
     """
     Args:

--- a/fv3core/pace/fv3core/stencils/neg_adj3.py
+++ b/fv3core/pace/fv3core/stencils/neg_adj3.py
@@ -4,7 +4,7 @@ from gt4py.cartesian.gtscript import BACKWARD, FORWARD, PARALLEL, computation, i
 import pace.util
 import pace.util.constants as constants
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.util import X_DIM, Y_DIM
 
 
@@ -343,12 +343,12 @@ class AdjustNegativeTracerMixingRatio:
         self._sum1 = quantity_factory.zeros(
             [X_DIM, Y_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._sum2 = quantity_factory.zeros(
             [X_DIM, Y_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         if check_negative:
             raise NotImplementedError(

--- a/fv3core/pace/fv3core/stencils/neg_adj3.py
+++ b/fv3core/pace/fv3core/stencils/neg_adj3.py
@@ -340,8 +340,16 @@ class AdjustNegativeTracerMixingRatio:
         hydrostatic: bool,
     ):
         grid_indexing = stencil_factory.grid_indexing
-        self._sum1 = quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
-        self._sum2 = quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
+        self._sum1 = quantity_factory.zeros(
+            [X_DIM, Y_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
+        self._sum2 = quantity_factory.zeros(
+            [X_DIM, Y_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
         if check_negative:
             raise NotImplementedError(
                 "Unimplemented namelist value check_negative=True"

--- a/fv3core/pace/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/pace/fv3core/stencils/nh_p_grad.py
@@ -9,7 +9,7 @@ from pace.util.grid import GridData
 
 
 def set_k0_and_calc_wk(
-    pp: FloatField, pk3: FloatField, wk: FloatField, top_value: float
+    pp: FloatField, pk3: FloatField, wk: FloatField, top_value: Float
 ):
     """
     Args:
@@ -34,7 +34,7 @@ def calc_u(
     pk3: FloatField,
     pp: FloatField,
     rdx: FloatFieldIJ,
-    dt: float,
+    dt: Float,
 ):
     """
     Args:
@@ -77,7 +77,7 @@ def calc_v(
     pk3: FloatField,
     pp: FloatField,
     rdy: FloatFieldIJ,
-    dt: float,
+    dt: Float,
 ):
     """
     Args:
@@ -199,9 +199,9 @@ class NonHydrostaticPressureGradient:
         gz: FloatField,
         pk3: FloatField,
         delp: FloatField,
-        dt: float,
-        ptop: float,
-        akap: float,
+        dt: Float,
+        ptop: Float,
+        akap: Float,
     ):
         """
         Updates the U and V winds due to pressure gradients,

--- a/fv3core/pace/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/pace/fv3core/stencils/nh_p_grad.py
@@ -140,10 +140,14 @@ class NonHydrostaticPressureGradient:
         self._rdy = grid_data.rdy
 
         self._tmp_wk = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], units="unknown"
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
         self._tmp_wk1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], units="unknown"
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
 
         self.a2b_k1 = AGrid2BGridFourthOrder(

--- a/fv3core/pace/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/pace/fv3core/stencils/nh_p_grad.py
@@ -2,7 +2,7 @@ from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
 import pace.util
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils.a2b_ord4 import AGrid2BGridFourthOrder
 from pace.util import X_DIM, Y_DIM, Z_INTERFACE_DIM
 from pace.util.grid import GridData
@@ -142,12 +142,12 @@ class NonHydrostaticPressureGradient:
         self._tmp_wk = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._tmp_wk1 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         self.a2b_k1 = AGrid2BGridFourthOrder(

--- a/fv3core/pace/fv3core/stencils/pe_halo.py
+++ b/fv3core/pace/fv3core/stencils/pe_halo.py
@@ -1,9 +1,9 @@
 from gt4py.cartesian.gtscript import FORWARD, computation, horizontal, interval, region
 
-from pace.dsl.typing import FloatField
+from pace.dsl.typing import Float, FloatField
 
 
-def edge_pe(pe: FloatField, delp: FloatField, ptop: float):
+def edge_pe(pe: FloatField, delp: FloatField, ptop: Float):
     """
     This corresponds to the pe_halo routine in FV3core
     Updading the interface pressure from the pressure differences

--- a/fv3core/pace/fv3core/stencils/pk3_halo.py
+++ b/fv3core/pace/fv3core/stencils/pk3_halo.py
@@ -9,7 +9,7 @@ from pace.util import X_DIM, Y_DIM
 # TODO merge with pe_halo? reuse partials?
 # NOTE: This is different from pace.fv3core.stencils.pe_halo.edge_pe
 def edge_pe_update(
-    pe: FloatFieldIJ, delp: FloatField, pk3: FloatField, ptop: float, akap: float
+    pe: FloatFieldIJ, delp: FloatField, pk3: FloatField, ptop: Float, akap: Float
 ):
     from __externals__ import local_ie, local_is, local_je, local_js
 
@@ -61,7 +61,7 @@ class PK3Halo:
             dtype=Float,
         )
 
-    def __call__(self, pk3: FloatField, delp: FloatField, ptop: float, akap: float):
+    def __call__(self, pk3: FloatField, delp: FloatField, ptop: Float, akap: Float):
         """Update pressure raised to the kappa (pk3) in halo region.
 
         Args:

--- a/fv3core/pace/fv3core/stencils/pk3_halo.py
+++ b/fv3core/pace/fv3core/stencils/pk3_halo.py
@@ -55,7 +55,11 @@ class PK3Halo:
             origin=origin,
             domain=domain,
         )
-        self._pe_tmp = quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
+        self._pe_tmp = quantity_factory.zeros(
+            [X_DIM, Y_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
 
     def __call__(self, pk3: FloatField, delp: FloatField, ptop: float, akap: float):
         """Update pressure raised to the kappa (pk3) in halo region.

--- a/fv3core/pace/fv3core/stencils/pk3_halo.py
+++ b/fv3core/pace/fv3core/stencils/pk3_halo.py
@@ -2,7 +2,7 @@ from gt4py.cartesian.gtscript import FORWARD, computation, horizontal, interval,
 
 import pace.util
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.util import X_DIM, Y_DIM
 
 
@@ -58,7 +58,7 @@ class PK3Halo:
         self._pe_tmp = quantity_factory.zeros(
             [X_DIM, Y_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
     def __call__(self, pk3: FloatField, delp: FloatField, ptop: float, akap: float):

--- a/fv3core/pace/fv3core/stencils/ray_fast.py
+++ b/fv3core/pace/fv3core/stencils/ray_fast.py
@@ -15,7 +15,7 @@ from gt4py.cartesian.gtscript import (
 import pace.util.constants as constants
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldK
+from pace.dsl.typing import Float, FloatField, FloatFieldK
 from pace.util import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
 
 
@@ -51,9 +51,9 @@ def ray_fast_wind_compute(
     w: FloatField,
     delta_p_ref: FloatFieldK,  # reference delta pressure
     pfull: FloatFieldK,  # input layer pressure reference?
-    dt: float,
-    ptop: float,
-    rf_cutoff_nudge: float,
+    dt: Float,
+    ptop: Float,
+    rf_cutoff_nudge: Float,
 ):
     """
     Args:
@@ -188,8 +188,8 @@ class RayleighDamping:
         w: FloatField,
         dp: FloatFieldK,
         pfull: FloatFieldK,
-        dt: float,
-        ptop: float,
+        dt: Float,
+        ptop: Float,
     ):
 
         rf_cutoff_nudge = self._rf_cutoff + min(100.0, 10.0 * ptop)

--- a/fv3core/pace/fv3core/stencils/remap_profile.py
+++ b/fv3core/pace/fv3core/stencils/remap_profile.py
@@ -594,9 +594,21 @@ class RemapProfile:
         assert kord <= 10, f"kord {kord} not implemented."
         self._kord = kord
 
-        self._gam = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
-        self._q = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
-        self._q_bot = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+        self._gam = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
+        self._q = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
+        self._q_bot = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
         self._extm = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="", dtype=bool)
         self._ext5 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="", dtype=bool)
         self._ext6 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="", dtype=bool)

--- a/fv3core/pace/fv3core/stencils/remap_profile.py
+++ b/fv3core/pace/fv3core/stencils/remap_profile.py
@@ -346,7 +346,7 @@ def set_interpolation_coefficients(
     ext5: BoolField,
     ext6: BoolField,
     extm: BoolField,
-    qmin: float,
+    qmin: Float,
 ):
     """
     Args:
@@ -639,7 +639,7 @@ class RemapProfile:
         a4_3: FloatField,
         a4_4: FloatField,
         delp: FloatField,
-        qmin: float = 0.0,
+        qmin: Float = 0.0,
     ):
         """
         Calculates the interpolation coefficients for a cubic-spline which models the

--- a/fv3core/pace/fv3core/stencils/remap_profile.py
+++ b/fv3core/pace/fv3core/stencils/remap_profile.py
@@ -13,7 +13,7 @@ from gt4py.cartesian.gtscript import (
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import BoolField, FloatField, FloatFieldIJ
+from pace.dsl.typing import BoolField, Float, FloatField, FloatFieldIJ
 from pace.util import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 
 
@@ -597,17 +597,17 @@ class RemapProfile:
         self._gam = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._q = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._q_bot = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._extm = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="", dtype=bool)
         self._ext5 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="", dtype=bool)

--- a/fv3core/pace/fv3core/stencils/remapping.py
+++ b/fv3core/pace/fv3core/stencils/remapping.py
@@ -17,7 +17,7 @@ import pace.fv3core.stencils.moist_cv as moist_cv
 import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from pace.fv3core._config import RemappingConfig
 from pace.fv3core.stencils.basic_operations import adjust_divide_stencil
 from pace.fv3core.stencils.map_single import MapSingle
@@ -327,48 +327,48 @@ class LagrangianToEulerian:
         self._pe1 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._pe2 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._pe3 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._dp2 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._pn2 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._pe0 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._pe3 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         self._gz = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m^2 s^-2",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._cvm = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         self._kord_tm = abs(config.kord_tm)

--- a/fv3core/pace/fv3core/stencils/remapping.py
+++ b/fv3core/pace/fv3core/stencils/remapping.py
@@ -39,7 +39,7 @@ from pace.util import (
 CONSV_MIN = 0.001
 
 
-def init_pe(pe: FloatField, pe1: FloatField, pe2: FloatField, ptop: float):
+def init_pe(pe: FloatField, pe1: FloatField, pe2: FloatField, ptop: Float):
     """
     Args:
         pe (in):
@@ -102,7 +102,7 @@ def moist_cv_pt_pressure(
     ps: FloatFieldIJ,
     pn2: FloatField,
     peln: FloatField,
-    r_vir: float,
+    r_vir: Float,
 ):
     """
     Computes Eulerian reference pressures as targets for remapping.
@@ -177,7 +177,7 @@ def pn2_pk_delp(
     pe2: FloatField,
     pn2: FloatField,
     pk: FloatField,
-    akap: float,
+    akap: Float,
 ):
     """
     Args:
@@ -540,12 +540,12 @@ class LagrangianToEulerian:
         ak: FloatFieldK,
         bk: FloatFieldK,
         dp1: FloatField,
-        ptop: float,
-        akap: float,
-        zvir: float,
+        ptop: Float,
+        akap: Float,
+        zvir: Float,
         last_step: bool,
-        consv_te: float,
-        mdt: float,
+        consv_te: Float,
+        mdt: Float,
     ):
         """
         Remap the deformed Lagrangian surfaces onto the reference, or "Eulerian",

--- a/fv3core/pace/fv3core/stencils/remapping.py
+++ b/fv3core/pace/fv3core/stencils/remapping.py
@@ -324,16 +324,52 @@ class LagrangianToEulerian:
             grid_indexing.domain[2] + 1,
         )
 
-        self._pe1 = quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa")
-        self._pe2 = quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa")
-        self._pe3 = quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa")
-        self._dp2 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="Pa")
-        self._pn2 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="Pa")
-        self._pe0 = quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa")
-        self._pe3 = quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa")
+        self._pe1 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._pe2 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._pe3 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._dp2 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._pn2 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._pe0 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._pe3 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
 
-        self._gz = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m^2 s^-2")
-        self._cvm = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+        self._gz = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m^2 s^-2",
+            dtype=pace.util.pfloat(),
+        )
+        self._cvm = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
+        )
 
         self._kord_tm = abs(config.kord_tm)
         self._kord_wz = config.kord_wz

--- a/fv3core/pace/fv3core/stencils/riem_solver3.py
+++ b/fv3core/pace/fv3core/stencils/riem_solver3.py
@@ -37,9 +37,9 @@ def precompute(
     gamma: FloatField,
     dz: FloatField,
     p_gas: FloatField,
-    ptop: float,
-    peln1: float,
-    ptk: float,
+    ptop: Float,
+    peln1: Float,
+    ptk: Float,
 ):
     """
     Args:
@@ -225,9 +225,9 @@ class NonhydrostaticVerticalSolver:
     def __call__(
         self,
         last_call: bool,
-        dt: float,
+        dt: Float,
         cappa: FloatField,
-        ptop: float,
+        ptop: Float,
         zs: FloatFieldIJ,
         ws: FloatFieldIJ,
         delz: FloatField,

--- a/fv3core/pace/fv3core/stencils/riem_solver3.py
+++ b/fv3core/pace/fv3core/stencils/riem_solver3.py
@@ -16,7 +16,7 @@ import pace.util
 import pace.util.constants as constants
 from pace.dsl.dace import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core._config import RiemannConfig
 from pace.fv3core.stencils.sim1_solver import Sim1Solver
 from pace.util import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
@@ -178,34 +178,34 @@ class NonhydrostaticVerticalSolver:
         self._delta_mass = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="kg",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._tmp_pe_init = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._p_gas = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._p_interface = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._log_p_interface = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="log(Pa)",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         # gamma parameter is (cp/cv)
         self._gamma = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         riemorigin = grid_indexing.origin_compute()

--- a/fv3core/pace/fv3core/stencils/riem_solver3.py
+++ b/fv3core/pace/fv3core/stencils/riem_solver3.py
@@ -175,20 +175,38 @@ class NonhydrostaticVerticalSolver:
         if config.a_imp <= 0.999:
             raise NotImplementedError("a_imp <= 0.999 is not implemented")
 
-        self._delta_mass = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="kg")
-        self._tmp_pe_init = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa"
+        self._delta_mass = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="kg",
+            dtype=pace.util.pfloat(),
         )
-        self._p_gas = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="Pa")
+        self._tmp_pe_init = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._p_gas = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
         self._p_interface = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa"
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
         )
         self._log_p_interface = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], units="log(Pa)"
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="log(Pa)",
+            dtype=pace.util.pfloat(),
         )
 
         # gamma parameter is (cp/cv)
-        self._gamma = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="")
+        self._gamma = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="",
+            dtype=pace.util.pfloat(),
+        )
 
         riemorigin = grid_indexing.origin_compute()
         domain = grid_indexing.domain_compute(add=(0, 0, 1))

--- a/fv3core/pace/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/pace/fv3core/stencils/riem_solver_c.py
@@ -145,13 +145,41 @@ class NonhydrostaticVerticalSolverCGrid:
         origin = grid_indexing.origin_compute(add=(-1, -1, 0))
         domain = grid_indexing.domain_compute(add=(2, 2, 1))
 
-        self._dm = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="kg")
-        self._w = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m/s")
-        self._pem = quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa")
-        self._pe = quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM], units="Pa")
-        self._gm = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="")
-        self._dz = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m")
-        self._pm = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="Pa")
+        self._dm = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="kg",
+            dtype=pace.util.pfloat(),
+        )
+        self._w = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m/s",
+            dtype=pace.util.pfloat(),
+        )
+        self._pem = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._pe = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._gm = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="",
+            dtype=pace.util.pfloat(),
+        )
+        self._dz = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m",
+            dtype=pace.util.pfloat(),
+        )
+        self._pm = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
 
         self._precompute_stencil = stencil_factory.from_origin_domain(
             precompute,

--- a/fv3core/pace/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/pace/fv3core/stencils/riem_solver_c.py
@@ -12,7 +12,7 @@ from gt4py.cartesian.gtscript import (
 import pace.util
 import pace.util.constants as constants
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils.sim1_solver import Sim1Solver
 from pace.util import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 
@@ -30,7 +30,7 @@ def precompute(
     dz: FloatField,  # is actually delta of gz
     gm: FloatField,
     pm: FloatField,
-    ptop: float,
+    ptop: Float,
 ):
     """
     Args:
@@ -148,37 +148,37 @@ class NonhydrostaticVerticalSolverCGrid:
         self._dm = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="kg",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._w = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m/s",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._pem = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._pe = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._gm = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._dz = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._pm = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         self._precompute_stencil = stencil_factory.from_origin_domain(

--- a/fv3core/pace/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/pace/fv3core/stencils/riem_solver_c.py
@@ -95,7 +95,7 @@ def finalize(
     dz: FloatField,
     pef: FloatField,
     gz: FloatField,
-    ptop: float,
+    ptop: Float,
 ):
     """
     Enforce vertical boundary conditions.
@@ -139,7 +139,7 @@ class NonhydrostaticVerticalSolverCGrid:
         self,
         stencil_factory: StencilFactory,
         quantity_factory: pace.util.QuantityFactory,
-        p_fac: float,
+        p_fac: Float,
     ):
         grid_indexing = stencil_factory.grid_indexing
         origin = grid_indexing.origin_compute(add=(-1, -1, 0))
@@ -199,9 +199,9 @@ class NonhydrostaticVerticalSolverCGrid:
 
     def __call__(
         self,
-        dt2: float,
+        dt2: Float,
         cappa: FloatField,
-        ptop: float,
+        ptop: Float,
         hs: FloatFieldIJ,
         ws: FloatFieldIJ,
         ptc: FloatField,

--- a/fv3core/pace/fv3core/stencils/saturation_adjustment.py
+++ b/fv3core/pace/fv3core/stencils/saturation_adjustment.py
@@ -13,7 +13,7 @@ from gt4py.cartesian.gtscript import (
 
 import pace.util.constants as constants
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core._config import SatAdjustConfig
 from pace.fv3core.stencils.basic_operations import dim
 from pace.fv3core.stencils.moist_cv import compute_pkz_func
@@ -576,22 +576,22 @@ def satadjust(
     area: FloatFieldIJ,
     hs: FloatFieldIJ,
     pkz: FloatField,
-    sdt: float,
-    zvir: float,
-    fac_i2s: float,
+    sdt: Float,
+    zvir: Float,
+    fac_i2s: Float,
     do_qa: bool,
     consv_te: bool,
-    c_air: float,
-    c_vap: float,
-    mdt: float,
-    fac_r2g: float,
-    fac_smlt: float,
-    fac_l2r: float,
-    fac_imlt: float,
-    d0_vap: float,
-    lv00: float,
-    fac_v2l: float,
-    fac_l2v: float,
+    c_air: Float,
+    c_vap: Float,
+    mdt: Float,
+    fac_r2g: Float,
+    fac_smlt: Float,
+    fac_l2r: Float,
+    fac_imlt: Float,
+    d0_vap: Float,
+    lv00: Float,
+    fac_v2l: Float,
+    fac_l2v: Float,
     last_step: bool,
 ):
     """
@@ -997,11 +997,11 @@ class SatAdjust3d:
         pt: FloatField,
         pkz: FloatField,
         cappa: FloatField,
-        r_vir: float,
-        mdt: float,
+        r_vir: Float,
+        mdt: Float,
         fast_mp_consv: bool,
         last_step: bool,
-        akap: float,
+        akap: Float,
         kmp: int,
     ):
         """

--- a/fv3core/pace/fv3core/stencils/sim1_solver.py
+++ b/fv3core/pace/fv3core/stencils/sim1_solver.py
@@ -12,7 +12,7 @@ from gt4py.cartesian.gtscript import (
 
 import pace.util.constants as constants
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.util import X_DIM, Y_DIM, Z_INTERFACE_DIM
 
 
@@ -28,10 +28,10 @@ def sim1_solver(
     pem: FloatField,
     ws: FloatFieldIJ,
     cp3: FloatField,
-    dt: float,
-    t1g: float,
-    rdt: float,
-    p_fac: float,
+    dt: Float,
+    t1g: Float,
+    rdt: Float,
+    p_fac: Float,
 ):
     """
     Tridiagonal solve for w and dz, handles pressure gradient force and sound waves
@@ -152,7 +152,7 @@ class Sim1Solver:
     def __init__(
         self,
         stencil_factory: StencilFactory,
-        p_fac: float,
+        p_fac: Float,
         n_halo: int,
     ):
         self._pfac = p_fac
@@ -164,7 +164,7 @@ class Sim1Solver:
 
     def __call__(
         self,
-        dt: float,
+        dt: Float,
         gamma: FloatField,
         cp3: FloatField,
         pe: FloatField,

--- a/fv3core/pace/fv3core/stencils/temperature_adjust.py
+++ b/fv3core/pace/fv3core/stencils/temperature_adjust.py
@@ -1,7 +1,7 @@
 from gt4py.cartesian.gtscript import PARALLEL, computation, exp, interval, log
 
 import pace.util.constants as constants
-from pace.dsl.typing import FloatField
+from pace.dsl.typing import Float, FloatField
 from pace.fv3core.stencils.basic_operations import sign
 
 
@@ -11,7 +11,7 @@ def apply_diffusive_heating(
     cappa: FloatField,
     heat_source: FloatField,
     pt: FloatField,
-    delt_time_factor: float,
+    delt_time_factor: Float,
 ):
     """
     Adjust air temperature from heating due to vorticity damping.

--- a/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
@@ -9,7 +9,7 @@ import pace.util
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.dace.wrapped_halo_exchange import WrappedHaloUpdater
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from pace.util import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 
@@ -197,32 +197,32 @@ class TracerAdvection:
         self._x_area_flux = quantity_factory.zeros(
             [X_INTERFACE_DIM, Y_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._y_area_flux = quantity_factory.zeros(
             [X_DIM, Y_INTERFACE_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._x_flux = quantity_factory.zeros(
             [X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._y_flux = quantity_factory.zeros(
             [X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM],
             units="unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._tmp_dp = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._tmp_dp2 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="Pa",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
         ax_offsets = grid_indexing.axis_offsets(
@@ -270,7 +270,7 @@ class TracerAdvection:
         tracer_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             n_halo=utils.halo,
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._tracers_halo_updater = WrappedHaloUpdater(
             comm.get_scalar_halo_updater([tracer_halo_spec] * self._tracer_count),

--- a/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
@@ -195,19 +195,35 @@ class TracerAdvection:
         self.grid_data = grid_data
 
         self._x_area_flux = quantity_factory.zeros(
-            [X_INTERFACE_DIM, Y_DIM, Z_DIM], units="unknown"
+            [X_INTERFACE_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
         self._y_area_flux = quantity_factory.zeros(
-            [X_DIM, Y_INTERFACE_DIM, Z_DIM], units="unknown"
+            [X_DIM, Y_INTERFACE_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
         self._x_flux = quantity_factory.zeros(
-            [X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM], units="unknown"
+            [X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
         self._y_flux = quantity_factory.zeros(
-            [X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM], units="unknown"
+            [X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM],
+            units="unknown",
+            dtype=pace.util.pfloat(),
         )
-        self._tmp_dp = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="Pa")
-        self._tmp_dp2 = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="Pa")
+        self._tmp_dp = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
+        self._tmp_dp2 = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="Pa",
+            dtype=pace.util.pfloat(),
+        )
 
         ax_offsets = grid_indexing.axis_offsets(
             grid_indexing.origin_full(), grid_indexing.domain_full()
@@ -254,6 +270,7 @@ class TracerAdvection:
         tracer_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             n_halo=utils.halo,
+            dtype=pace.util.pfloat(),
         )
         self._tracers_halo_updater = WrappedHaloUpdater(
             comm.get_scalar_halo_updater([tracer_halo_spec] * self._tracer_count),

--- a/fv3core/pace/fv3core/stencils/updatedzc.py
+++ b/fv3core/pace/fv3core/stencils/updatedzc.py
@@ -4,7 +4,7 @@ from gt4py.cartesian.gtscript import BACKWARD, FORWARD, PARALLEL, computation, i
 import pace.util
 import pace.util.constants as constants
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from pace.stencils import corners
 from pace.util import X_DIM, Y_DIM, Z_DIM
 
@@ -136,18 +136,18 @@ class UpdateGeopotentialHeightOnCGrid:
         self._dp_ref = quantity_factory.zeros(
             dp_ref.dims,
             units=dp_ref.units,
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._dp_ref.view[:] = dp_ref.view[:]
         self._gz_x = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m**2/s**2",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._gz_y = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="m**2/s**2",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         full_origin = grid_indexing.origin_full()
         full_domain = grid_indexing.domain_full(add=(0, 0, 1))

--- a/fv3core/pace/fv3core/stencils/updatedzc.py
+++ b/fv3core/pace/fv3core/stencils/updatedzc.py
@@ -133,10 +133,22 @@ class UpdateGeopotentialHeightOnCGrid:
         # e.g. by adding a quantity.factory
         # attribute, or by implementing basic math like slicing, addition, etc.
         # here it's needed to ensure we have a buffer point after the compute domain
-        self._dp_ref = quantity_factory.zeros(dp_ref.dims, units=dp_ref.units)
+        self._dp_ref = quantity_factory.zeros(
+            dp_ref.dims,
+            units=dp_ref.units,
+            dtype=pace.util.pfloat(),
+        )
         self._dp_ref.view[:] = dp_ref.view[:]
-        self._gz_x = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m**2/s**2")
-        self._gz_y = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="m**2/s**2")
+        self._gz_x = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m**2/s**2",
+            dtype=pace.util.pfloat(),
+        )
+        self._gz_y = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_DIM],
+            units="m**2/s**2",
+            dtype=pace.util.pfloat(),
+        )
         full_origin = grid_indexing.origin_full()
         full_domain = grid_indexing.domain_full(add=(0, 0, 1))
         self._double_copy_stencil = stencil_factory.from_origin_domain(

--- a/fv3core/pace/fv3core/stencils/updatedzc.py
+++ b/fv3core/pace/fv3core/stencils/updatedzc.py
@@ -69,7 +69,7 @@ def update_dz_c(
     gz_y: FloatField,
     ws: FloatFieldIJ,
     *,
-    dt: float,
+    dt: Float,
 ):
     """
     Step dz forward on c-grid
@@ -183,7 +183,7 @@ class UpdateGeopotentialHeightOnCGrid:
         vt: FloatField,
         gz: FloatField,
         ws: FloatFieldIJ,
-        dt: float,
+        dt: Float,
     ):
         """
         Args:

--- a/fv3core/pace/fv3core/stencils/updatedzd.py
+++ b/fv3core/pace/fv3core/stencils/updatedzd.py
@@ -141,9 +141,21 @@ def cubic_spline_interpolation_constants(
         beta: interpolation constant on mid levels
         gamma: interpolation constant on mid levels
     """
-    gk = quantity_factory.zeros([Z_DIM], units="")
-    beta = quantity_factory.zeros([Z_DIM], units="")
-    gamma = quantity_factory.zeros([Z_DIM], units="")
+    gk = quantity_factory.zeros(
+        [Z_DIM],
+        units="",
+        dtype=pace.util.pfloat(),
+    )
+    beta = quantity_factory.zeros(
+        [Z_DIM],
+        units="",
+        dtype=pace.util.pfloat(),
+    )
+    gamma = quantity_factory.zeros(
+        [Z_DIM],
+        units="",
+        dtype=pace.util.pfloat(),
+    )
     gk.view[0] = dp0.view[1] / dp0.view[0]
     beta.view[0] = gk.view[0] * (gk.view[0] + 0.5)
     gamma.view[0] = (1.0 + gk.view[0] * (gk.view[0] + 1.5)) / beta.view[0]
@@ -255,29 +267,49 @@ class UpdateHeightOnDGrid:
 
     def _allocate_temporary_storages(self, quantity_factory: pace.util.QuantityFactory):
         self._crx_interface = quantity_factory.zeros(
-            [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM], ""
+            [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "",
+            dtype=pace.util.pfloat(),
         )
         self._cry_interface = quantity_factory.zeros(
-            [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM], ""
+            [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM],
+            "",
+            dtype=pace.util.pfloat(),
         )
         self._x_area_flux_interface = quantity_factory.zeros(
-            [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM], "m^2"
+            [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "m^2",
+            dtype=pace.util.pfloat(),
         )
         self._y_area_flux_interface = quantity_factory.zeros(
-            [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM], "m^2"
+            [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM],
+            "m^2",
+            dtype=pace.util.pfloat(),
         )
-        self._wk = quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM], "unknown")
+        self._wk = quantity_factory.zeros(
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "unknown",
+            dtype=pace.util.pfloat(),
+        )
         self._height_x_diffusive_flux = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], "unknown"
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "unknown",
+            dtype=pace.util.pfloat(),
         )
         self._height_y_diffusive_flux = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], "unknown"
+            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "unknown",
+            dtype=pace.util.pfloat(),
         )
         self._fx = quantity_factory.zeros(
-            [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM], "unknown"
+            [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "unknown",
+            dtype=pace.util.pfloat(),
         )
         self._fy = quantity_factory.zeros(
-            [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM], "unknown"
+            [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM],
+            "unknown",
+            dtype=pace.util.pfloat(),
         )
 
     def __call__(

--- a/fv3core/pace/fv3core/stencils/updatedzd.py
+++ b/fv3core/pace/fv3core/stencils/updatedzd.py
@@ -7,7 +7,7 @@ import pace.util
 import pace.util.constants as constants
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from pace.fv3core.stencils.delnflux import DelnFluxNoSG
 from pace.fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from pace.util import (
@@ -144,17 +144,17 @@ def cubic_spline_interpolation_constants(
     gk = quantity_factory.zeros(
         [Z_DIM],
         units="",
-        dtype=pace.util.pfloat(),
+        dtype=Float,
     )
     beta = quantity_factory.zeros(
         [Z_DIM],
         units="",
-        dtype=pace.util.pfloat(),
+        dtype=Float,
     )
     gamma = quantity_factory.zeros(
         [Z_DIM],
         units="",
-        dtype=pace.util.pfloat(),
+        dtype=Float,
     )
     gk.view[0] = dp0.view[1] / dp0.view[0]
     beta.view[0] = gk.view[0] * (gk.view[0] + 0.5)
@@ -269,47 +269,47 @@ class UpdateHeightOnDGrid:
         self._crx_interface = quantity_factory.zeros(
             [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM],
             "",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._cry_interface = quantity_factory.zeros(
             [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM],
             "",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._x_area_flux_interface = quantity_factory.zeros(
             [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM],
             "m^2",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._y_area_flux_interface = quantity_factory.zeros(
             [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM],
             "m^2",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._wk = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             "unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._height_x_diffusive_flux = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             "unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._height_y_diffusive_flux = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_INTERFACE_DIM],
             "unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._fx = quantity_factory.zeros(
             [X_INTERFACE_DIM, Y_DIM, Z_INTERFACE_DIM],
             "unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self._fy = quantity_factory.zeros(
             [X_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM],
             "unknown",
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
 
     def __call__(

--- a/fv3core/pace/fv3core/stencils/updatedzd.py
+++ b/fv3core/pace/fv3core/stencils/updatedzd.py
@@ -78,7 +78,7 @@ def apply_height_fluxes(
     gz_y_diffusive_flux: FloatField,
     surface_height: FloatFieldIJ,
     ws: FloatFieldIJ,
-    dt: float,
+    dt: Float,
 ):
     """
     Apply all computed fluxes to height profile.
@@ -321,7 +321,7 @@ class UpdateHeightOnDGrid:
         x_area_flux: FloatField,
         y_area_flux: FloatField,
         ws: FloatFieldIJ,
-        dt: float,
+        dt: Float,
     ):
         """
         Advect height on D-grid.

--- a/fv3core/pace/fv3core/stencils/xtp_u.py
+++ b/fv3core/pace/fv3core/stencils/xtp_u.py
@@ -1,7 +1,7 @@
 from gt4py.cartesian import gtscript
 from gt4py.cartesian.gtscript import __INLINED, compile_assert, horizontal, region
 
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils import ppm, xppm
 
 
@@ -56,7 +56,7 @@ def advect_u_along_x(
     rdx: FloatFieldIJ,
     dx: FloatFieldIJ,
     dxa: FloatFieldIJ,
-    dt: float,
+    dt: Float,
 ):
     """
     Advect covariant x-wind on D-grid using contravariant x-wind on cell corners.

--- a/fv3core/pace/fv3core/stencils/ytp_v.py
+++ b/fv3core/pace/fv3core/stencils/ytp_v.py
@@ -1,7 +1,7 @@
 from gt4py.cartesian import gtscript
 from gt4py.cartesian.gtscript import __INLINED, compile_assert, horizontal, region
 
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.fv3core.stencils import ppm, yppm
 
 
@@ -56,7 +56,7 @@ def advect_v_along_y(
     rdy: FloatFieldIJ,
     dy: FloatFieldIJ,
     dya: FloatFieldIJ,
-    dt: float,
+    dt: Float,
 ):
     """
     Advect covariant y-wind on D-grid using contravariant y-wind on cell corners.

--- a/fv3core/tests/savepoint/translate/translate_haloupdate.py
+++ b/fv3core/tests/savepoint/translate/translate_haloupdate.py
@@ -163,7 +163,6 @@ class TranslateHaloVectorUpdate(ParallelTranslate):
             pace_log.debug(f"starting on {communicator.rank}")
             req_list.append(
                 communicator.start_vector_halo_update(
-                    state["x_wind_on_c_grid"].data.dtype,
                     state["x_wind_on_c_grid"],
                     state["y_wind_on_c_grid"],
                     n_points=utils.halo,

--- a/fv3core/tests/savepoint/translate/translate_haloupdate.py
+++ b/fv3core/tests/savepoint/translate/translate_haloupdate.py
@@ -167,6 +167,7 @@ class TranslateHaloVectorUpdate(ParallelTranslate):
             logger.debug(f"starting on {communicator.rank}")
             req_list.append(
                 communicator.start_vector_halo_update(
+                    state["x_wind_on_c_grid"].data.dtype,
                     state["x_wind_on_c_grid"],
                     state["y_wind_on_c_grid"],
                     n_points=utils.halo,

--- a/fv3core/tests/savepoint/translate/translate_haloupdate.py
+++ b/fv3core/tests/savepoint/translate/translate_haloupdate.py
@@ -1,13 +1,9 @@
-import logging
-
 import pace.dsl
 import pace.util
 import pace.util as fv3util
 from pace.dsl import gt4py_utils as utils
 from pace.stencils.testing import ParallelTranslate
-
-
-logger = logging.getLogger("fv3ser")
+from pace.util.logging import pace_log
 
 
 class TranslateHaloUpdate(ParallelTranslate):
@@ -51,14 +47,14 @@ class TranslateHaloUpdate(ParallelTranslate):
         state_list = self.state_list_from_inputs_list(inputs_list)
         req_list = []
         for state, communicator in zip(state_list, communicator_list):
-            logger.debug(f"starting on {communicator.rank}")
+            pace_log.debug(f"starting on {communicator.rank}")
             req_list.append(
                 communicator.start_halo_update(
                     state[self.halo_update_varname], n_points=utils.halo
                 )
             )
         for communicator, req in zip(communicator_list, req_list):
-            logger.debug(f"finishing on {communicator.rank}")
+            pace_log.debug(f"finishing on {communicator.rank}")
             req.wait()
         return self.outputs_list_from_state_list(state_list)
 
@@ -150,13 +146,13 @@ class TranslateHaloVectorUpdate(ParallelTranslate):
         super(TranslateHaloVectorUpdate, self).__init__(grid, namelist, stencil_factory)
 
     def compute_parallel(self, inputs, communicator):
-        logger.debug(f"starting on {communicator.rank}")
+        pace_log.debug(f"starting on {communicator.rank}")
         state = self.state_from_inputs(inputs)
         req = communicator.start_vector_halo_update(
             state["x_wind_on_c_grid"], state["y_wind_on_c_grid"], n_points=utils.halo
         )
 
-        logger.debug(f"finishing on {communicator.rank}")
+        pace_log.debug(f"finishing on {communicator.rank}")
         req.wait()
         return self.outputs_from_state(state)
 
@@ -164,7 +160,7 @@ class TranslateHaloVectorUpdate(ParallelTranslate):
         state_list = self.state_list_from_inputs_list(inputs_list)
         req_list = []
         for state, communicator in zip(state_list, communicator_list):
-            logger.debug(f"starting on {communicator.rank}")
+            pace_log.debug(f"starting on {communicator.rank}")
             req_list.append(
                 communicator.start_vector_halo_update(
                     state["x_wind_on_c_grid"].data.dtype,
@@ -174,7 +170,7 @@ class TranslateHaloVectorUpdate(ParallelTranslate):
                 )
             )
         for communicator, req in zip(communicator_list, req_list):
-            logger.debug(f"finishing on {communicator.rank}")
+            pace_log.debug(f"finishing on {communicator.rank}")
             req.wait()
         return self.outputs_list_from_state_list(state_list)
 
@@ -222,12 +218,12 @@ class TranslateMPPBoundaryAdjust(ParallelTranslate):
         )
 
     def compute_parallel(self, inputs, communicator):
-        logger.debug(f"starting on {communicator.rank}")
+        pace_log.debug(f"starting on {communicator.rank}")
         state = self.state_from_inputs(inputs)
         req = communicator.start_synchronize_vector_interfaces(
             state["x_wind_on_d_grid"], state["y_wind_on_d_grid"]
         )
-        logger.debug(f"finishing on {communicator.rank}")
+        pace_log.debug(f"finishing on {communicator.rank}")
         req.wait()
         return self.outputs_from_state(state)
 
@@ -241,6 +237,6 @@ class TranslateMPPBoundaryAdjust(ParallelTranslate):
                 )
             )
         for communicator, req in zip(communicator_list, req_list):
-            logger.debug(f"finishing on {communicator.rank}")
+            pace_log.debug(f"finishing on {communicator.rank}")
             req.wait()
         return self.outputs_list_from_state_list(state_list)

--- a/physics/pace/physics/physics_state.py
+++ b/physics/pace/physics/physics_state.py
@@ -290,7 +290,7 @@ class PhysicsState:
             tendency = quantity_factory.zeros(
                 [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
                 "unknown",
-                dtype=float,
+                dtype=pace.util.pfloat(),
             )
             self.microphysics: Optional[MicrophysicsState] = MicrophysicsState(
                 pt=self.pt,
@@ -321,7 +321,9 @@ class PhysicsState:
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
                 initial_arrays[_field.name] = quantity_factory.zeros(
-                    _field.metadata["dims"], _field.metadata["units"], dtype=float
+                    _field.metadata["dims"],
+                    _field.metadata["units"],
+                    dtype=pace.util.pfloat(),
                 ).data
         return cls(
             **initial_arrays,

--- a/physics/pace/physics/physics_state.py
+++ b/physics/pace/physics/physics_state.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 import pace.dsl.gt4py_utils as gt_utils
 import pace.util
+from pace.dsl.typing import Float
 from pace.physics.stencils.microphysics import MicrophysicsState
 
 
@@ -290,7 +291,7 @@ class PhysicsState:
             tendency = quantity_factory.zeros(
                 [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
                 "unknown",
-                dtype=pace.util.pfloat(),
+                dtype=Float,
             )
             self.microphysics: Optional[MicrophysicsState] = MicrophysicsState(
                 pt=self.pt,
@@ -323,7 +324,7 @@ class PhysicsState:
                 initial_arrays[_field.name] = quantity_factory.zeros(
                     _field.metadata["dims"],
                     _field.metadata["units"],
-                    dtype=pace.util.pfloat(),
+                    dtype=Float,
                 ).data
         return cls(
             **initial_arrays,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ dask>=2021.10.0
 netCDF4
 cftime
 fv3config>=0.9.0
-dace>=0.14
+dace>=0.14.1
 f90nml>=1.1.0
 numpy>=1.15
 -e external/gt4py

--- a/stencils/pace/stencils/c2l_ord.py
+++ b/stencils/pace/stencils/c2l_ord.py
@@ -5,7 +5,7 @@ import pace.util
 from pace import fv3core
 from pace.dsl.dace.wrapped_halo_exchange import WrappedHaloUpdater
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ
+from pace.dsl.typing import Float, FloatField, FloatFieldIJ
 from pace.util.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from pace.util.grid import GridData
 
@@ -149,12 +149,12 @@ class CubedToLatLon:
         full_size_xyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM],
             n_halo=grid_indexing.n_halo,
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         full_size_xiyz_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM],
             n_halo=grid_indexing.n_halo,
-            dtype=pace.util.pfloat(),
+            dtype=Float,
         )
         self.u__v = WrappedHaloUpdater(
             comm.get_vector_halo_updater(

--- a/stencils/pace/stencils/c2l_ord.py
+++ b/stencils/pace/stencils/c2l_ord.py
@@ -149,10 +149,12 @@ class CubedToLatLon:
         full_size_xyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM],
             n_halo=grid_indexing.n_halo,
+            dtype=pace.util.pfloat(),
         )
         full_size_xiyz_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM],
             n_halo=grid_indexing.n_halo,
+            dtype=pace.util.pfloat(),
         )
         self.u__v = WrappedHaloUpdater(
             comm.get_vector_halo_updater(

--- a/stencils/pace/stencils/corners.py
+++ b/stencils/pace/stencils/corners.py
@@ -1004,40 +1004,32 @@ def fill_corners_dgrid_defn(
         # sw corner
         with horizontal(region[i_start - 1, j_start - 1]):
             x_out = mysign * y_in[0, 1, 0]
-        with horizontal(region[i_start - 1, j_start - 1]):
             y_out = mysign * x_in[1, 0, 0]
         with horizontal(region[i_start - 1, j_start - 2]):
             x_out = mysign * y_in[-1, 2, 0]
-        with horizontal(region[i_start - 1, j_start - 2]):
             y_out = mysign * x_in[2, 1, 0]
         with horizontal(region[i_start - 1, j_start - 3]):
             x_out = mysign * y_in[-2, 3, 0]
-        with horizontal(region[i_start - 1, j_start - 3]):
             y_out = mysign * x_in[3, 2, 0]
         with horizontal(region[i_start - 2, j_start - 1]):
             x_out = mysign * y_in[1, 2, 0]
-        with horizontal(region[i_start - 2, j_start - 1]):
             y_out = mysign * x_in[2, -1, 0]
         with horizontal(region[i_start - 2, j_start - 2]):
             x_out = mysign * y_in[0, 3, 0]
-        with horizontal(region[i_start - 2, j_start - 2]):
             y_out = mysign * x_in[3, 0, 0]
         with horizontal(region[i_start - 2, j_start - 3]):
             x_out = mysign * y_in[-1, 4, 0]
-        with horizontal(region[i_start - 2, j_start - 3]):
             y_out = mysign * x_in[4, 1, 0]
         with horizontal(region[i_start - 3, j_start - 1]):
             x_out = mysign * y_in[2, 3, 0]
-        with horizontal(region[i_start - 3, j_start - 1]):
             y_out = mysign * x_in[3, -2, 0]
         with horizontal(region[i_start - 3, j_start - 2]):
             x_out = mysign * y_in[1, 4, 0]
-        with horizontal(region[i_start - 3, j_start - 2]):
             y_out = mysign * x_in[4, -1, 0]
         with horizontal(region[i_start - 3, j_start - 3]):
             x_out = mysign * y_in[0, 5, 0]
-        with horizontal(region[i_start - 3, j_start - 3]):
             y_out = mysign * x_in[5, 0, 0]
+
         # ne corner
         with horizontal(region[i_end + 1, j_end + 2]):
             x_out = mysign * y_in[1, -2, 0]
@@ -1047,105 +1039,91 @@ def fill_corners_dgrid_defn(
             x_out = mysign * y_in[2, -3, 0]
         with horizontal(region[i_end + 2, j_end + 2]):
             y_out = mysign * x_in[-3, 0, 0]
+            x_out = mysign * y_in[0, -3, 0]
         with horizontal(region[i_end + 1, j_end + 4]):
             x_out = mysign * y_in[3, -4, 0]
         with horizontal(region[i_end + 2, j_end + 3]):
             y_out = mysign * x_in[-4, -1, 0]
-        with horizontal(region[i_end + 2, j_end + 2]):
-            x_out = mysign * y_in[0, -3, 0]
+            x_out = mysign * y_in[1, -4, 0]
         with horizontal(region[i_end + 3, j_end + 1]):
             y_out = mysign * x_in[-3, 2, 0]
-        with horizontal(region[i_end + 2, j_end + 3]):
-            x_out = mysign * y_in[1, -4, 0]
         with horizontal(region[i_end + 3, j_end + 2]):
             y_out = mysign * x_in[-4, 1, 0]
+            x_out = mysign * y_in[-1, -4, 0]
         with horizontal(region[i_end + 2, j_end + 4]):
             x_out = mysign * y_in[2, -5, 0]
         with horizontal(region[i_end + 3, j_end + 3]):
             y_out = mysign * x_in[-5, 0, 0]
-        with horizontal(region[i_end + 3, j_end + 2]):
-            x_out = mysign * y_in[-1, -4, 0]
+            x_out = mysign * y_in[0, -5, 0]
         with horizontal(region[i_end + 4, j_end + 1]):
             y_out = mysign * x_in[-4, 3, 0]
-        with horizontal(region[i_end + 3, j_end + 3]):
-            x_out = mysign * y_in[0, -5, 0]
         with horizontal(region[i_end + 4, j_end + 2]):
             y_out = mysign * x_in[-5, 2, 0]
         with horizontal(region[i_end + 3, j_end + 4]):
             x_out = mysign * y_in[1, -6, 0]
         with horizontal(region[i_end + 4, j_end + 3]):
             y_out = mysign * x_in[-6, 1, 0]
+
         # nw corner
         with horizontal(region[i_start - 1, j_end + 2]):
             x_out = y_in[0, -2, 0]
+            y_out = x_in[2, 0, 0]
         with horizontal(region[i_start - 1, j_end + 1]):
             y_out = x_in[1, 1, 0]
         with horizontal(region[i_start - 1, j_end + 3]):
             x_out = y_in[-1, -3, 0]
-        with horizontal(region[i_start - 1, j_end + 2]):
-            y_out = x_in[2, 0, 0]
+            y_out = x_in[3, -1, 0]
         with horizontal(region[i_start - 1, j_end + 4]):
             x_out = y_in[-2, -4, 0]
-        with horizontal(region[i_start - 1, j_end + 3]):
-            y_out = x_in[3, -1, 0]
         with horizontal(region[i_start - 2, j_end + 2]):
             x_out = y_in[1, -3, 0]
+            y_out = x_in[3, 1, 0]
         with horizontal(region[i_start - 2, j_end + 1]):
             y_out = x_in[2, 2, 0]
         with horizontal(region[i_start - 2, j_end + 3]):
             x_out = y_in[0, -4, 0]
-        with horizontal(region[i_start - 2, j_end + 2]):
-            y_out = x_in[3, 1, 0]
+            y_out = x_in[4, 0, 0]
         with horizontal(region[i_start - 2, j_end + 4]):
             x_out = y_in[-1, -5, 0]
-        with horizontal(region[i_start - 2, j_end + 3]):
-            y_out = x_in[4, 0, 0]
         with horizontal(region[i_start - 3, j_end + 2]):
             x_out = y_in[2, -4, 0]
+            y_out = x_in[4, 2, 0]
         with horizontal(region[i_start - 3, j_end + 1]):
             y_out = x_in[3, 3, 0]
         with horizontal(region[i_start - 3, j_end + 3]):
             x_out = y_in[1, -5, 0]
-        with horizontal(region[i_start - 3, j_end + 2]):
-            y_out = x_in[4, 2, 0]
+            y_out = x_in[5, 1, 0]
         with horizontal(region[i_start - 3, j_end + 4]):
             x_out = y_in[0, -6, 0]
-        with horizontal(region[i_start - 3, j_end + 3]):
-            y_out = x_in[5, 1, 0]
+
         # se corner
         with horizontal(region[i_end + 1, j_start - 1]):
             x_out = y_in[1, 1, 0]
         with horizontal(region[i_end + 2, j_start - 1]):
             y_out = x_in[-2, 0, 0]
+            x_out = y_in[0, 2, 0]
         with horizontal(region[i_end + 1, j_start - 2]):
             x_out = y_in[2, 2, 0]
         with horizontal(region[i_end + 2, j_start - 2]):
             y_out = x_in[-3, 1, 0]
+            x_out = y_in[1, 3, 0]
         with horizontal(region[i_end + 1, j_start - 3]):
             x_out = y_in[3, 3, 0]
         with horizontal(region[i_end + 2, j_start - 3]):
             y_out = x_in[-4, 2, 0]
-        with horizontal(region[i_end + 2, j_start - 1]):
-            x_out = y_in[0, 2, 0]
+            x_out = y_in[2, 4, 0]
         with horizontal(region[i_end + 3, j_start - 1]):
             y_out = x_in[-3, -1, 0]
-        with horizontal(region[i_end + 2, j_start - 2]):
-            x_out = y_in[1, 3, 0]
+            x_out = y_in[-1, 3, 0]
         with horizontal(region[i_end + 3, j_start - 2]):
             y_out = x_in[-4, 0, 0]
-        with horizontal(region[i_end + 2, j_start - 3]):
-            x_out = y_in[2, 4, 0]
+            x_out = y_in[0, 4, 0]
         with horizontal(region[i_end + 3, j_start - 3]):
             y_out = x_in[-5, 1, 0]
-        with horizontal(region[i_end + 3, j_start - 1]):
-            x_out = y_in[-1, 3, 0]
+            x_out = y_in[1, 5, 0]
         with horizontal(region[i_end + 4, j_start - 1]):
             y_out = x_in[-4, -2, 0]
-        with horizontal(region[i_end + 3, j_start - 2]):
-            x_out = y_in[0, 4, 0]
         with horizontal(region[i_end + 4, j_start - 2]):
             y_out = x_in[-5, -1, 0]
-        with horizontal(region[i_end + 3, j_start - 3]):
-            x_out = y_in[1, 5, 0]
         with horizontal(region[i_end + 4, j_start - 3]):
             y_out = x_in[-6, 0, 0]

--- a/tests/main/dsl/test_stencil_wrapper.py
+++ b/tests/main/dsl/test_stencil_wrapper.py
@@ -11,7 +11,7 @@ from pace.dsl.dace.dace_config import DaceConfig, DaCeOrchestration
 from pace.dsl.gt4py_utils import make_storage_from_shape
 from pace.dsl.stencil import FrozenStencil, _convert_quantities_to_storage
 from pace.dsl.stencil_config import CompilationConfig, StencilConfig
-from pace.dsl.typing import FloatField
+from pace.dsl.typing import Float, FloatField
 
 
 def get_stencil_config(
@@ -241,6 +241,7 @@ def test_frozen_stencil_kwargs_passed_to_init(
         externals={},
         **config.stencil_kwargs(func=copy_stencil),
         build_info={},
+        dtypes={float: Float},
     )
 
 

--- a/tests/main/fv3core/test_init_from_geos.py
+++ b/tests/main/fv3core/test_init_from_geos.py
@@ -82,9 +82,7 @@ def test_geos_wrapper():
     comm = NullComm(rank=0, total_ranks=6, fill_value=0.0)
     backend = "numpy"
 
-    wrapper = fv3core.GeosDycoreWrapper(
-        namelist, comm, namelist_dict["dt_atmos"], backend
-    )
+    wrapper = fv3core.GeosDycoreWrapper(namelist, comm, backend)
     nhalo = 3
     shape_centered = (
         namelist["nx_tile"] + 2 * nhalo,

--- a/tests/main/fv3core/test_init_from_geos.py
+++ b/tests/main/fv3core/test_init_from_geos.py
@@ -82,7 +82,9 @@ def test_geos_wrapper():
     comm = NullComm(rank=0, total_ranks=6, fill_value=0.0)
     backend = "numpy"
 
-    wrapper = fv3core.GeosDycoreWrapper(namelist, comm, backend)
+    wrapper = fv3core.GeosDycoreWrapper(
+        namelist, comm, namelist_dict["dt_atmos"], backend
+    )
     nhalo = 3
     shape_centered = (
         namelist["nx_tile"] + 2 * nhalo,

--- a/util/HISTORY.md
+++ b/util/HISTORY.md
@@ -4,10 +4,13 @@ History
 latest
 ------
 
+- Added f32 support to halo exchange data transformation
+
 v0.10.0
 -------
 
 Major changes:
+
 - Added the following attributes/methods to Communicator: `tile`, `halo_update`, `boundaries`, `start_halo_update`, `vector_halo_update`, `start_vector_halo_update`, `synchronize_vector_interfaces`, `start_synchronize_vector_interfaces`, `get_scalar_halo_updater`, and `get_vector_halo_updater`
 - Added Checkpointer and NullCheckpointer classes
 - Added SnapshotCheckpointer
@@ -20,6 +23,7 @@ Major changes:
 - Added NetCDFMonitor for saving the global state in time-chunked NetCDF files
 
 Minor changes:
+
 - Deleted deprecated `finish_halo_update` method from CubedSphereCommunicator
 - fixed a bug in `pace.util.grid` where `_reduce_global_area_minmaxes` would use local values instead of the gathered ones
 - Added .cleanup() method to ZarrMonitor, used only for API compatibility with NetCDFMonitor and does nothing
@@ -27,6 +31,7 @@ Minor changes:
 - Quantity no longer has a `storage` attribute - the ndarray is directly accessible through the `data` attribute.
 
 Minor changes:
+
 - Fixed a bug in normalize_vector(xyz) in `pace.util.grid.gnomonic` where it would divide the input by cells-per-tile, where it should not.
 - Refactored `pace.util.grid.helper` so that `HorizontalGridData`, `VerticalGridData`, `ContravariantGridData` and `AngleGridData` have their own `new_from_metric_terms` class methods, and `GridData` calls those in its own method definition.
 - Added `stretch_transformation` to `pace.util.grid` - stretches the grid as needed for refinement, tropical test case.
@@ -35,12 +40,14 @@ v0.9.0
 ------
 
 Major changes:
+
 - Modified `pace.util.Quantity.transpose` to retain attributes, and loosened `pace.util.ZarrMonitor.store` requirements on attribute consistency, both to ease fv3net integration issues not addressed in v0.8.0
 
 v0.8.0
 ------
 
 Major changes:
+
 - Changed `ZarrMonitor.store` behavior to allow passing quantities with different dimension orders
 - Added `CachingCommWriter` which wraps a `Comm` object and can be serialized to a file-like object with a `.dump` method
 - Added `CachingCommReader` which can be loaded from the dump output of `CachingCommWriter` and replays its communication in the order it occurred.
@@ -52,6 +59,7 @@ Major changes:
 - TilePartitioner has a new `edge_interior_ratio` argument which defaults to 1.0, and lets the user specify the relative 1-dimensional extent of the compute domains of ranks on tile edges and corners relative to ranks on the tile interior. In all cases, the closest valid value will be used, which enables some previously invalid configurations (e.g. C128 on a 3 by 3 layout will use the closest valid edge_interior_ratio to 1.0)
 
 Minor changes:
+
 - The `split_cartesian_into_storages` method is moved out of pace-util, as it is more generally used, and now lives in pace.dsl.gt4py_utils
 - created `DriverGridData.new_from_grid_variables` class method to initialize from grid variable data
 - updated QuantityFactory to accept the more generic GridSizer class on initialization
@@ -66,6 +74,7 @@ v0.7.0
 ------
 
 Major changes:
+
 - Renamed package from fv3gfs-util to pace-util
 - Added NullTimer to use for default Timer value, it is a disabled timer which cannot be enabled (raises NotImplementedError)
 - Added pace.util.grid, keeping symbols out of top level as they are still unstable
@@ -73,9 +82,11 @@ Major changes:
 - Added physical constants to pace.util.constants
 
 Minor changes:
+
 - Added method set_extra_dim_lengths to QuantityFactory
 
 Fixes:
+
 - Fixed bug where ZarrMonitor depended on dict `.items()` always returning items in the same order
 
 Other changes may exist in this version, as we temporarily paused updating the history on each PR.
@@ -84,6 +95,7 @@ v0.6.0
 ------
 
 Major changes:
+
 - Use `cftime.datetime` objects to represent datetimes instead
 of `datetime.datetime` objects.  This results in times stored in a format compatible with
 the fortran model, and accurate internal representation of times with the calendar specified
@@ -108,6 +120,7 @@ in the `coupler_nml` namelist.
 - make data type of quantity and storage reflect the gt4py_backend chosen, instead of being determined based on the data type being numpy/cupy
 
 Fixes:
+
 - If `only_names` is provided to `open_restart`, it will return those fields and nothing more.  Previously it would include `"time"` in the returned state even if it was not requested.
 - Fixed a bug where quantity.storage and quantity.data could be out of sync if the quantity was initialized using data and a gt4py backend string
 - Default slice for corner views when not given at all as an index (e.g. when providing one index to a 2D view) now gives the same result as providing an empty slice (:)
@@ -122,15 +135,18 @@ v0.5.0
 ------
 
 Breaking changes:
+
 - `send_buffer` and `recv_buffer` are modified to take in a `callable`, which is more easily serialized than a `numpy`-like module (necessary because we serialize the arguments to re-use buffers), and allows custom specification of the initialization if zeros are needed instead of empty.
 
 Major changes:
+
 - Added additional regional views to Quantity as attributes on Quantity.view, including `northeast`, `northwest`, `southeast`, `southwest`, and `interior`
 - Separated fv3util into its own repository and began tracking history separately from fv3gfs-python
 - Added getters and setters for additional dynamics quantities needed to call an alternative dynamical core
 - Added `storage` property to Quantity, implemented as short-term shortcut to .data until gt4py GDP-3 is implemented
 
 Deprecations:
+
 - `Quantity.values` is deprecated
 
 v0.4.3 (2020-05-15)

--- a/util/pace/util/__init__.py
+++ b/util/pace/util/__init__.py
@@ -54,6 +54,7 @@ from .halo_updater import HaloUpdater, HaloUpdateRequest
 from .initialization import GridSizer, QuantityFactory, SubtileGridSizer
 from .io import read_state, write_state
 from .local_comm import LocalComm
+from .logging import pace_log
 from .monitor import Monitor, NetCDFMonitor, ZarrMonitor
 from .mpi import MPIComm
 from .namelist import Namelist, NamelistDefaults

--- a/util/pace/util/__init__.py
+++ b/util/pace/util/__init__.py
@@ -68,6 +68,7 @@ from .partitioner import (
 from .quantity import Quantity, QuantityMetadata
 from .time import FMS_TO_CFTIME_TYPE, datetime64_to_datetime
 from .units import UnitsError, ensure_equal_units, units_are_equal
+from .utils import pfloat
 
 
 __version__ = "0.10.0"

--- a/util/pace/util/__init__.py
+++ b/util/pace/util/__init__.py
@@ -68,7 +68,6 @@ from .partitioner import (
 from .quantity import Quantity, QuantityMetadata
 from .time import FMS_TO_CFTIME_TYPE, datetime64_to_datetime
 from .units import UnitsError, ensure_equal_units, units_are_equal
-from .utils import pfloat
 
 
 __version__ = "0.10.0"

--- a/util/pace/util/communicator.py
+++ b/util/pace/util/communicator.py
@@ -176,6 +176,7 @@ class Communicator(abc.ABC):
             origin=tuple([0 for dim in send_metadata.dims]),
             extent=global_extent,
             gt4py_backend=send_metadata.gt4py_backend,
+            allow_mismatch_float_precision=True,
         )
         return recv_quantity
 
@@ -188,6 +189,7 @@ class Communicator(abc.ABC):
             dims=send_metadata.dims,
             units=send_metadata.units,
             gt4py_backend=send_metadata.gt4py_backend,
+            allow_mismatch_float_precision=True,
         )
         return recv_quantity
 
@@ -267,7 +269,10 @@ class Communicator(abc.ABC):
             else:
                 gather_value = to_numpy(quantity.view[:], dtype=transfer_type)
                 gather_quantity = Quantity(
-                    data=gather_value, dims=quantity.dims, units=quantity.units
+                    data=gather_value,
+                    dims=quantity.dims,
+                    units=quantity.units,
+                    allow_mismatch_float_precision=True,
                 )
                 if recv_state is not None and name in recv_state:
                     tile_quantity = self.gather(
@@ -749,6 +754,7 @@ class CubedSphereCommunicator(Communicator):
             origin=(0,) + tuple([0 for dim in metadata.dims]),
             extent=global_extent,
             gt4py_backend=metadata.gt4py_backend,
+            allow_mismatch_float_precision=True,
         )
         return recv_quantity
 
@@ -768,5 +774,6 @@ class CubedSphereCommunicator(Communicator):
             dims=metadata.dims[1:],
             units=metadata.units,
             gt4py_backend=metadata.gt4py_backend,
+            allow_mismatch_float_precision=True,
         )
         return recv_quantity

--- a/util/pace/util/cuda_kernels.py
+++ b/util/pace/util/cuda_kernels.py
@@ -2,135 +2,105 @@
 from ._optional_imports import cupy as cp
 
 
-pack_scalar_f64_kernel = (
-    None
-    if cp is None
-    else cp.RawKernel(
-        r"""
-        extern "C" __global__
-        void pack_scalar_f64(const double* i_sourceArray,
-                            const int* i_indexes,
-                            const int i_nIndex,
-                            const int i_offset,
-                            double* o_destinationBuffer)
-        {
-            int tid = blockDim.x * blockIdx.x + threadIdx.x;
-            if (tid>=i_nIndex)
-            {
-                return;
-            }
-
-            o_destinationBuffer[i_offset+tid] = i_sourceArray[i_indexes[tid]];
-        }
-
-        """,
-        "pack_scalar_f64",
-    )
-)
-"""Pack into o_destinationBuffer data from i_sourceArray.
+def pack_scalar_code(float_dtype: str):
+    """Pack into o_destinationBuffer data from i_sourceArray.
 
     The indexation into i_sourceArray is stored in i_indexes.
     i_offset is the offset in the destination buffer.
     i_nIndex allows to protect from out-of-bound read in kernel.
 
     tid is the global unique index calculated from the CUDA scheduler inner data.
-"""
+    """
+    return r"""
+    extern "C" __global__
+    void pack_scalar_{fdtype}(const {fdtype}* i_sourceArray,
+                        const int* i_indexes,
+                        const int i_nIndex,
+                        const int i_offset,
+                        {fdtype}* o_destinationBuffer)
+    {{
+        int tid = blockDim.x * blockIdx.x + threadIdx.x;
+        if (tid>=i_nIndex)
+        {{
+            return;
+        }}
+
+        o_destinationBuffer[i_offset+tid] = i_sourceArray[i_indexes[tid]];
+    }}
+
+    """.format(
+        fdtype=float_dtype
+    )
 
 
-unpack_scalar_f64_kernel = (
-    None
-    if cp is None
-    else cp.RawKernel(
-        r"""
+def unpack_scalar_code(float_dtype: str):
+    """Unpack into o_destinationArray data from i_sourceBuffer.
+
+    The indexation into o_destinationArray is stored in i_indexes.
+    i_offset is the offset in the source buffer.
+    i_nIndex allows to protect from out-of-bound read in kernel.
+
+    tid is the global unique index calculated from the CUDA scheduler inner data.
+    """
+    return r"""
             extern "C" __global__
-            void unpack_scalar_f64(const double* i_sourceBuffer,
+            void unpack_scalar_{fdtype}(const {fdtype}* i_sourceBuffer,
                                 const int* i_indexes,
                                 const int i_nIndex,
                                 const int i_offset,
-                                double* o_destinationArray)
-            {
+                                {fdtype}* o_destinationArray)
+            {{
                 int tid = blockDim.x * blockIdx.x + threadIdx.x;
                 if (tid>=i_nIndex)
                     return;
 
                 o_destinationArray[i_indexes[tid]] = i_sourceBuffer[i_offset+tid];
-            }
+            }}
 
-            """,
-        "unpack_scalar_f64",
+            """.format(
+        fdtype=float_dtype
     )
-)
-"""Unpack into o_destinationArray data from i_sourceBuffer.
-
-The indexation into o_destinationArray is stored in i_indexes.
-i_offset is the offset in the source buffer.
-i_nIndex allows to protect from out-of-bound read in kernel.
-
-tid is the global unique index calculated from the CUDA scheduler inner data.
-"""
 
 
-# Expect rotate >= 0 in [0:4[
-pack_vector_f64_kernel = (
+pack_scalar_f64_kernel = (
     None
     if cp is None
     else cp.RawKernel(
-        r"""
-    extern "C" __global__
-    void pack_vector_f64(const double* i_sourceArrayX,
-                        const double* i_sourceArrayY,
-                        const int* i_indexesX,
-                        const int* i_indexesY,
-                        const int i_nIndexX,
-                        const int i_nIndexY,
-                        const int i_offset,
-                        const int i_rotate,
-                        double* o_destinationBuffer)
-    {
-        int tid = blockDim.x * blockIdx.x + threadIdx.x;
-        if (tid>=i_nIndexX+i_nIndexY)
-            return;
-
-        if (i_rotate == 0)
-        {
-            //pass
-            if (tid<i_nIndexX)
-                o_destinationBuffer[i_offset+tid] = i_sourceArrayX[i_indexesX[tid]];
-            else
-                o_destinationBuffer[i_offset+tid] = i_sourceArrayY[i_indexesY[tid-i_nIndexX]];
-        }
-        else if (i_rotate == 1)
-        {
-            //data[0], data[1] = data[1], -data[0]
-            if (tid<i_nIndexY)
-                o_destinationBuffer[i_offset+tid] = i_sourceArrayY[i_indexesY[tid]];
-            else
-                o_destinationBuffer[i_offset+tid] = -1.0 * i_sourceArrayX[i_indexesX[tid-i_nIndexY]];
-        }
-        else if (i_rotate == 2)
-        {
-            //data[0], data[1] = -data[0], -data[1]
-            if (tid<i_nIndexX)
-                o_destinationBuffer[i_offset+tid] = -1.0 * i_sourceArrayX[i_indexesX[tid]];
-            else
-                o_destinationBuffer[i_offset+tid] = -1.0 * i_sourceArrayY[i_indexesY[tid-i_nIndexX]];
-        }
-        else if (i_rotate == 3)
-        {
-            //data[0], data[1] = -data[1], data[0]
-            if (tid<i_nIndexY)
-                o_destinationBuffer[i_offset+tid] = -1.0 * i_sourceArrayY[i_indexesY[tid]];
-            else
-                o_destinationBuffer[i_offset+tid] = i_sourceArrayX[i_indexesX[tid-i_nIndexY]];
-        }
-
-    }
-
-    """,
-        "pack_vector_f64",
+        pack_scalar_code("double"),
+        "pack_scalar_double",
     )
 )
-"""Pack into o_destinationBuffer data from i_sourceArrayX/Y.
+
+pack_scalar_f32_kernel = (
+    None
+    if cp is None
+    else cp.RawKernel(
+        pack_scalar_code("float"),
+        "pack_scalar_float",
+    )
+)
+
+unpack_scalar_f64_kernel = (
+    None
+    if cp is None
+    else cp.RawKernel(
+        unpack_scalar_code("double"),
+        "unpack_scalar_double",
+    )
+)
+
+unpack_scalar_f32_kernel = (
+    None
+    if cp is None
+    else cp.RawKernel(
+        unpack_scalar_code("float"),
+        "unpack_scalar_float",
+    )
+)
+
+
+def pack_vector_code(float_dtype: str) -> str:
+    """Pack into o_destinationBuffer data from i_sourceArrayX/Y.
 
     The indexation into i_sourceArrayX/Y is stored in i_indexesX/Y.
     i_offset is the offset in the destination buffer.
@@ -138,41 +108,129 @@ pack_vector_f64_kernel = (
     i_rotate refers to the rotation that needs to be applied prior to assignment.
 
     tid is the global unique index calculated from the CUDA scheduler inner data.
-"""
+    """
+    # Expect rotate >= 0 in [0:4[
+    return r"""
+    extern "C" __global__
+    void pack_vector_{fdtype}(const {fdtype}* i_sourceArrayX,
+                        const {fdtype}* i_sourceArrayY,
+                        const int* i_indexesX,
+                        const int* i_indexesY,
+                        const int i_nIndexX,
+                        const int i_nIndexY,
+                        const int i_offset,
+                        const int i_rotate,
+                        {fdtype}* o_destinationBuffer)
+    {{
+        int tid = blockDim.x * blockIdx.x + threadIdx.x;
+        if (tid>=i_nIndexX+i_nIndexY)
+            return;
 
-
-unpack_vector_f64_kernel = (
-    None
-    if cp is None
-    else cp.RawKernel(
-        r"""
-        extern "C" __global__
-        void unpack_vector_f64(const double* i_sourceBuffer,
-                            const int* i_indexesX,
-                            const int* i_indexesY,
-                            const int i_nIndexX,
-                            const int i_nIndexY,
-                            const int i_offset,
-                            double* o_destinationArrayX,
-                            double* o_destinationArrayY)
-        {
-            int tid = blockDim.x * blockIdx.x + threadIdx.x;
-
+        if (i_rotate == 0)
+        {{
+            //pass
             if (tid<i_nIndexX)
-                o_destinationArrayX[i_indexesX[tid]] = i_sourceBuffer[i_offset+tid];
-            else if (tid<i_nIndexX+i_nIndexY)
-                o_destinationArrayY[i_indexesY[tid-i_nIndexX]] = i_sourceBuffer[i_offset+tid];
-        }
+                o_destinationBuffer[i_offset+tid] = i_sourceArrayX[i_indexesX[tid]];
+            else
+                o_destinationBuffer[i_offset+tid] = i_sourceArrayY[i_indexesY[tid-i_nIndexX]];
+        }}
+        else if (i_rotate == 1)
+        {{
+            //data[0], data[1] = data[1], -data[0]
+            if (tid<i_nIndexY)
+                o_destinationBuffer[i_offset+tid] = i_sourceArrayY[i_indexesY[tid]];
+            else
+                o_destinationBuffer[i_offset+tid] = -1.0 * i_sourceArrayX[i_indexesX[tid-i_nIndexY]];
+        }}
+        else if (i_rotate == 2)
+        {{
+            //data[0], data[1] = -data[0], -data[1]
+            if (tid<i_nIndexX)
+                o_destinationBuffer[i_offset+tid] = -1.0 * i_sourceArrayX[i_indexesX[tid]];
+            else
+                o_destinationBuffer[i_offset+tid] = -1.0 * i_sourceArrayY[i_indexesY[tid-i_nIndexX]];
+        }}
+        else if (i_rotate == 3)
+        {{
+            //data[0], data[1] = -data[1], data[0]
+            if (tid<i_nIndexY)
+                o_destinationBuffer[i_offset+tid] = -1.0 * i_sourceArrayY[i_indexesY[tid]];
+            else
+                o_destinationBuffer[i_offset+tid] = i_sourceArrayX[i_indexesX[tid-i_nIndexY]];
+        }}
 
-        """,
-        "unpack_vector_f64",
+    }}
+
+    """.format(
+        fdtype=float_dtype
     )
-)
-"""Unpack into o_destinationArrayX/Y data from i_sourceBuffer.
+
+
+def unpack_vector_code(float_dtype: str) -> str:
+    """Unpack into o_destinationArrayX/Y data from i_sourceBuffer.
 
     The indexation into o_destinationArrayX/Y is stored in i_indexesX/Y.
     i_offset is the offset in the source buffer.
     i_nIndexX/Y allows to protect from out-of-bound read in kernel.
 
     tid is the global unique index calculated from the CUDA scheduler inner data.
-"""
+    """
+    return r"""
+        extern "C" __global__
+        void unpack_vector_{fdtype}(const {fdtype}* i_sourceBuffer,
+                            const int* i_indexesX,
+                            const int* i_indexesY,
+                            const int i_nIndexX,
+                            const int i_nIndexY,
+                            const int i_offset,
+                            {fdtype}* o_destinationArrayX,
+                            {fdtype}* o_destinationArrayY)
+        {{
+            int tid = blockDim.x * blockIdx.x + threadIdx.x;
+
+            if (tid<i_nIndexX)
+                o_destinationArrayX[i_indexesX[tid]] = i_sourceBuffer[i_offset+tid];
+            else if (tid<i_nIndexX+i_nIndexY)
+                o_destinationArrayY[i_indexesY[tid-i_nIndexX]] = i_sourceBuffer[i_offset+tid];
+        }}
+
+        """.format(
+        fdtype=float_dtype
+    )
+
+
+pack_vector_f64_kernel = (
+    None
+    if cp is None
+    else cp.RawKernel(
+        pack_vector_code("double"),
+        "pack_vector_double",
+    )
+)
+pack_vector_f32_kernel = (
+    None
+    if cp is None
+    else cp.RawKernel(
+        pack_vector_code("float"),
+        "pack_vector_float",
+    )
+)
+
+
+unpack_vector_f64_kernel = (
+    None
+    if cp is None
+    else cp.RawKernel(
+        unpack_vector_code("double"),
+        "unpack_vector_double",
+    )
+)
+
+unpack_vector_f32_kernel = (
+    None
+    if cp is None
+    else cp.RawKernel(
+        unpack_vector_code("float"),
+        "unpack_vector_float",
+    )
+)

--- a/util/pace/util/grid/generation.py
+++ b/util/pace/util/grid/generation.py
@@ -237,14 +237,16 @@ class MetricTerms:
         self._grid = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=float,
+            dtype=util.pfloat(),
         )
         npx, npy, ndims = self._tile_partitioner.global_extent(self._grid)
         self._npx = npx
         self._npy = npy
         self._npz = self.quantity_factory.sizer.get_extent(util.Z_DIM)[0]
         self._agrid = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_DIM, self.LON_OR_LAT_DIM], "radians", dtype=float
+            [util.X_DIM, util.Y_DIM, self.LON_OR_LAT_DIM],
+            "radians",
+            dtype=util.pfloat(),
         )
         self._np = self._grid.np
         self._dx = None
@@ -1478,17 +1480,17 @@ class MetricTerms:
         grid_mirror_ew = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=float,
+            dtype=util.pfloat(),
         )
         grid_mirror_ns = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=float,
+            dtype=util.pfloat(),
         )
         grid_mirror_diag = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=float,
+            dtype=util.pfloat(),
         )
 
         local_west_edge = self._tile_partitioner.on_tile_left(self._rank)
@@ -1642,7 +1644,11 @@ class MetricTerms:
         )
 
     def _compute_dxdy(self):
-        dx = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "m")
+        dx = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "m",
+            dtype=util.pfloat(),
+        )
 
         dx.view[:, :] = great_circle_distance_along_axis(
             self._grid.view[:, :, 0],
@@ -1651,7 +1657,11 @@ class MetricTerms:
             self._np,
             axis=0,
         )
-        dy = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "m")
+        dy = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "m",
+            dtype=util.pfloat(),
+        )
         dy.view[:, :] = great_circle_distance_along_axis(
             self._grid.view[:, :, 0],
             self._grid.view[:, :, 1],
@@ -1677,8 +1687,16 @@ class MetricTerms:
 
     def _compute_dxdy_agrid(self):
 
-        dx_agrid = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "m")
-        dy_agrid = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "m")
+        dx_agrid = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "m",
+            dtype=util.pfloat(),
+        )
+        dy_agrid = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "m",
+            dtype=util.pfloat(),
+        )
         lon, lat = self._grid.data[:, :, 0], self._grid.data[:, :, 1]
         lon_y_center, lat_y_center = lon_lat_midpoint(
             lon[:, :-1], lon[:, 1:], lat[:, :-1], lat[:, 1:], self._np
@@ -1712,8 +1730,16 @@ class MetricTerms:
         return dx_agrid, dy_agrid
 
     def _compute_dxdy_center(self):
-        dx_center = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "m")
-        dy_center = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "m")
+        dx_center = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "m",
+            dtype=util.pfloat(),
+        )
+        dy_center = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "m",
+            dtype=util.pfloat(),
+        )
 
         lon_agrid, lat_agrid = (
             self._agrid.data[:-1, :-1, 0],
@@ -1772,7 +1798,11 @@ class MetricTerms:
         return dx_center, dy_center
 
     def _compute_area(self):
-        area = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "m^2")
+        area = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "m^2",
+            dtype=util.pfloat(),
+        )
         area.data[:, :] = -1.0e8
 
         area.data[3:-4, 3:-4] = get_area(
@@ -1786,7 +1816,9 @@ class MetricTerms:
 
     def _compute_area_c(self):
         area_cgrid = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], "m^2"
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "m^2",
+            dtype=util.pfloat(),
         )
         area_cgrid.data[3:-3, 3:-3] = get_area(
             self._agrid.data[2:-3, 2:-3, 0],
@@ -1826,9 +1858,21 @@ class MetricTerms:
         return area_cgrid
 
     def _set_hybrid_pressure_coefficients(self):
-        ptop = self.quantity_factory.zeros([], "Pa")
-        ak = self.quantity_factory.zeros([util.Z_INTERFACE_DIM], "Pa")
-        bk = self.quantity_factory.zeros([util.Z_INTERFACE_DIM], "")
+        ptop = self.quantity_factory.zeros(
+            [],
+            "Pa",
+            dtype=util.pfloat(),
+        )
+        ak = self.quantity_factory.zeros(
+            [util.Z_INTERFACE_DIM],
+            "Pa",
+            dtype=util.pfloat(),
+        )
+        bk = self.quantity_factory.zeros(
+            [util.Z_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         pressure_coefficients = set_hybrid_pressure_coefficients(self._npz)
         ptop = pressure_coefficients.ptop
         ak.data[:] = asarray(pressure_coefficients.ak, type(ak.data))
@@ -1837,10 +1881,14 @@ class MetricTerms:
 
     def _calculate_center_vectors(self):
         ec1 = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM], ""
+            [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         ec2 = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM], ""
+            [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         ec1.data[:] = self._np.nan
         ec2.data[:] = self._np.nan
@@ -1856,10 +1904,14 @@ class MetricTerms:
 
     def _calculate_vectors_west(self):
         ew1 = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM, self.CARTESIAN_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         ew2 = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM, self.CARTESIAN_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         ew1.data[:] = self._np.nan
         ew2.data[:] = self._np.nan
@@ -1876,10 +1928,14 @@ class MetricTerms:
 
     def _calculate_vectors_south(self):
         es1 = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM], ""
+            [util.X_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         es2 = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM], ""
+            [util.X_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         es1.data[:] = self._np.nan
         es2.data[:] = self._np.nan
@@ -1895,22 +1951,60 @@ class MetricTerms:
         return es1, es2
 
     def _calculate_more_trig_terms(self, cos_sg, sin_sg):
-        cosa_u = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "")
-        cosa_v = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
-        cosa_s = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        sina_u = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "")
-        sina_v = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
-        rsin_u = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "")
-        rsin_v = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
-        rsina = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+        cosa_u = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
         )
-        rsin2 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
+        cosa_v = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        cosa_s = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        sina_u = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        sina_v = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        rsin_u = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        rsin_v = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        rsina = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        rsin2 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         cosa = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         sina = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         (
             cosa.data[:, :],
@@ -1950,33 +2044,59 @@ class MetricTerms:
     def _init_cell_trigonometry(self):
 
         self._cosa_u = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._cosa_v = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
-        self._cosa_s = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
+        self._cosa_s = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         self._sina_u = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._sina_v = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._rsin_u = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._rsin_v = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._rsina = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
-        self._rsin2 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
+        self._rsin2 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         self._cosa = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._sina = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
 
         # This section calculates the cos_sg and sin_sg terms, which describe the
@@ -2028,11 +2148,15 @@ class MetricTerms:
         supergrid_trig = {}
         for i in range(1, 10):
             supergrid_trig[f"cos_sg{i}"] = self.quantity_factory.zeros(
-                [util.X_DIM, util.Y_DIM], ""
+                [util.X_DIM, util.Y_DIM],
+                "",
+                dtype=util.pfloat(),
             )
             supergrid_trig[f"cos_sg{i}"].data[:-1, :-1] = cos_sg[:, :, i - 1]
             supergrid_trig[f"sin_sg{i}"] = self.quantity_factory.zeros(
-                [util.X_DIM, util.Y_DIM], ""
+                [util.X_DIM, util.Y_DIM],
+                "",
+                dtype=util.pfloat(),
             )
             supergrid_trig[f"sin_sg{i}"].data[:-1, :-1] = sin_sg[:, :, i - 1]
 
@@ -2061,33 +2185,55 @@ class MetricTerms:
         in-place without the halo updates. For use only in validation tests.
         """
         self._cosa_u = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._cosa_v = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._cosa_s = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
         self._sina_u = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._sina_v = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._rsin_u = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._rsin_v = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._rsina = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
-        self._rsin2 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
+        self._rsin2 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         self._cosa = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         self._sina = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
         )
 
         cos_sg = self._np.array(
@@ -2140,8 +2286,16 @@ class MetricTerms:
         )
 
     def _calculate_latlon_momentum_correction(self):
-        l2c_v = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "")
-        l2c_u = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
+        l2c_v = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        l2c_u = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         (
             l2c_v.data[self._halo : -self._halo, self._halo : -self._halo - 1],
             l2c_u.data[self._halo : -self._halo - 1, self._halo : -self._halo],
@@ -2150,10 +2304,14 @@ class MetricTerms:
 
     def _calculate_xy_unit_vectors(self):
         ee1 = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         ee2 = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM], ""
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         ee1.data[:] = self._np.nan
         ee2.data[:] = self._np.nan
@@ -2166,10 +2324,26 @@ class MetricTerms:
         return ee1, ee2
 
     def _calculate_divg_del6(self):
-        del6_u = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
-        del6_v = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "")
-        divg_u = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
-        divg_v = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "")
+        del6_u = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        del6_v = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        divg_u = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        divg_v = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         sin_sg = [
             self.sin_sg1.data[:-1, :-1],
             self.sin_sg2.data[:-1, :-1],
@@ -2211,10 +2385,26 @@ class MetricTerms:
         As _calculate_divg_del6 but updates self.divg and self.del6 attributes
         in-place without the halo updates. For use only in validation tests.
         """
-        del6_u = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
-        del6_v = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "")
-        divg_u = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
-        divg_v = self.quantity_factory.zeros([util.X_INTERFACE_DIM, util.Y_DIM], "")
+        del6_u = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        del6_v = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        divg_u = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        divg_v = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         sin_sg = [
             self.sin_sg1.data[:-1, :-1],
             self.sin_sg2.data[:-1, :-1],
@@ -2247,10 +2437,14 @@ class MetricTerms:
 
     def _calculate_unit_vectors_lonlat(self):
         vlon = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM], ""
+            [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
         vlat = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM], ""
+            [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
+            "",
+            dtype=util.pfloat(),
         )
 
         vlon.data[:-1, :-1], vlat.data[:-1, :-1] = unit_vector_lonlat(
@@ -2259,10 +2453,26 @@ class MetricTerms:
         return vlon, vlat
 
     def _calculate_grid_z(self):
-        z11 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        z12 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        z21 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        z22 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
+        z11 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        z12 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        z21 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        z22 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         (
             z11.data[:-1, :-1],
             z12.data[:-1, :-1],
@@ -2278,10 +2488,26 @@ class MetricTerms:
         return z11, z12, z21, z22
 
     def _calculate_grid_a(self):
-        a11 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        a12 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        a21 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        a22 = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
+        a11 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        a12 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        a21 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        a22 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         (
             a11.data[:-1, :-1],
             a12.data[:-1, :-1],
@@ -2298,10 +2524,26 @@ class MetricTerms:
 
     def _calculate_edge_factors(self):
         nhalo = self._halo
-        edge_s = self.quantity_factory.zeros([util.X_INTERFACE_DIM], "")
-        edge_n = self.quantity_factory.zeros([util.X_INTERFACE_DIM], "")
-        edge_e = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
-        edge_w = self.quantity_factory.zeros([util.X_DIM, util.Y_INTERFACE_DIM], "")
+        edge_s = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        edge_n = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        edge_e = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        edge_w = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         (
             edge_w.data[:, nhalo:-nhalo],
             edge_e.data[:, nhalo:-nhalo],
@@ -2320,10 +2562,26 @@ class MetricTerms:
         return edge_w, edge_e, edge_s, edge_n
 
     def _calculate_edge_a2c_vect_factors(self):
-        edge_vect_s = self.quantity_factory.zeros([util.X_DIM], "")
-        edge_vect_n = self.quantity_factory.zeros([util.X_DIM], "")
-        edge_vect_e = self.quantity_factory.zeros([util.Y_DIM], "")
-        edge_vect_w = self.quantity_factory.zeros([util.Y_DIM], "")
+        edge_vect_s = self.quantity_factory.zeros(
+            [util.X_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        edge_vect_n = self.quantity_factory.zeros(
+            [util.X_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        edge_vect_e = self.quantity_factory.zeros(
+            [util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        edge_vect_w = self.quantity_factory.zeros(
+            [util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         (
             edge_vect_w.data[:-1],
             edge_vect_e.data[:-1],
@@ -2342,8 +2600,16 @@ class MetricTerms:
         return edge_vect_w, edge_vect_e, edge_vect_s, edge_vect_n
 
     def _calculate_2d_edge_a2c_vect_factors(self):
-        edge_vect_e_2d = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        edge_vect_w_2d = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
+        edge_vect_e_2d = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
+        edge_vect_w_2d = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=util.pfloat(),
+        )
         shape = self.lon.data.shape
         east_edge_data = self.edge_vect_e_1d.data[self._np.newaxis, ...]
         east_edge_data = self._np.repeat(east_edge_data, shape[0], axis=0)

--- a/util/pace/util/grid/generation.py
+++ b/util/pace/util/grid/generation.py
@@ -3,6 +3,8 @@ import functools
 import warnings
 from typing import Tuple
 
+import numpy as np
+
 from pace import util
 from pace.dsl.gt4py_utils import asarray
 from pace.dsl.stencil import GridIndexing
@@ -67,6 +69,15 @@ def ignore_zero_division(func):
             return func(*args, **kwargs)
 
     return wrapped
+
+
+def quantity_cast_to_model_float(
+    quantity_factory: util.QuantityFactory, qty_64: util.Quantity
+) -> util.Quantity:
+    """Copy & cast from 64-bit float to model precision if need be"""
+    qty = quantity_factory.empty(qty_64.dims, qty_64.units, dtype=Float)
+    qty.data[:] = qty_64.data[:]
+    return qty
 
 
 @dataclasses.dataclass
@@ -235,21 +246,29 @@ class MetricTerms:
             util.Y_INTERFACE_DIM,
             self.LON_OR_LAT_DIM,
         ]
-        self._grid = self.quantity_factory.zeros(
+        self._grid_64 = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        npx, npy, ndims = self._tile_partitioner.global_extent(self._grid)
+        # This will carry the public version of the grid
+        # for the selected floating point precision
+        self._grid = None
+        npx, npy, ndims = self._tile_partitioner.global_extent(self._grid_64)
         self._npx = npx
         self._npy = npy
         self._npz = self.quantity_factory.sizer.get_extent(util.Z_DIM)[0]
-        self._agrid = self.quantity_factory.zeros(
+        self._agrid_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.LON_OR_LAT_DIM],
             "radians",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._np = self._grid.np
+        # This will carry the public version of the agrid
+        # for the selected floating point precision
+        self._agrid = None
+        self._np = self._grid_64.np
         self._dx = None
         self._dy = None
         self._dx_agrid = None
@@ -361,6 +380,10 @@ class MetricTerms:
 
     @property
     def grid(self):
+        if not self._grid:
+            self._grid = quantity_cast_to_model_float(
+                self.quantity_factory, self._grid_64
+            )
         return self._grid
 
     @property
@@ -368,14 +391,18 @@ class MetricTerms:
         """
         the longitudes and latitudes of the cell corners
         """
-        return self._grid
+        return self.grid
 
     @property
     def gridvar(self):
-        return self._grid
+        return self.grid
 
     @property
     def agrid(self):
+        if not self._agrid:
+            self._agrid = quantity_cast_to_model_float(
+                self.quantity_factory, self._agrid_64
+            )
         return self._agrid
 
     @property
@@ -383,7 +410,7 @@ class MetricTerms:
         """
         the longitudes and latitudes of the cell centers
         """
-        return self._agrid
+        return self.agrid
 
     @property
     def lon(self):
@@ -1344,7 +1371,7 @@ class MetricTerms:
         cartesian coordinates of each dgrid cell center
         """
         return lon_lat_to_xyz(
-            self._grid.data[:, :, 0], self._grid.data[:, :, 1], self._np
+            self._grid_64.data[:, :, 0], self._grid_64.data[:, :, 1], self._np
         )
 
     @cached_property
@@ -1353,8 +1380,8 @@ class MetricTerms:
         cartesian coordinates of each agrid cell center
         """
         return lon_lat_to_xyz(
-            self._agrid.data[:-1, :-1, 0],
-            self._agrid.data[:-1, :-1, 1],
+            self._agrid_64.data[:-1, :-1, 0],
+            self._agrid_64.data[:-1, :-1, 1],
             self._np,
         )
 
@@ -1481,17 +1508,20 @@ class MetricTerms:
         grid_mirror_ew = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         grid_mirror_ns = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         grid_mirror_diag = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
 
         local_west_edge = self._tile_partitioner.on_tile_left(self._rank)
@@ -1500,7 +1530,7 @@ class MetricTerms:
         local_north_edge = self._tile_partitioner.on_tile_top(self._rank)
         # information on position of subtile in full tile
         slice_x, slice_y = self._tile_partitioner.subtile_slice(
-            self._rank, self._grid.dims, (self._npx, self._npy), overlap=True
+            self._rank, self._grid_64.dims, (self._npx, self._npy), overlap=True
         )
         section_global_is = self._halo + slice_x.start
         section_global_js = self._halo + slice_y.start
@@ -1509,8 +1539,8 @@ class MetricTerms:
 
         # compute gnomonic grid for this rank
         local_gnomonic_ed(
-            self._grid.view[:, :, 0],
-            self._grid.view[:, :, 1],
+            self._grid_64.view[:, :, 0],
+            self._grid_64.view[:, :, 1],
             npx=self._npx,
             west_edge=local_west_edge,
             east_edge=local_east_edge,
@@ -1587,7 +1617,7 @@ class MetricTerms:
         # Average the mirrored gnomonic grids
         tile_index = self._partitioner.tile_index(self._rank)
         mirror_data = {
-            "local": self._grid.data,
+            "local": self._grid_64.data,
             "east-west": grid_mirror_ew.data,
             "north-south": grid_mirror_ns.data,
             "diagonal": grid_mirror_diag.data,
@@ -1602,7 +1632,7 @@ class MetricTerms:
             global_is=section_global_is,
             global_js=section_global_js,
             ng=self._halo,
-            np=self._grid.np,
+            np=self._grid_64.np,
             right_hand_grid=self.RIGHT_HAND_GRID,
         )
 
@@ -1610,95 +1640,103 @@ class MetricTerms:
         # This will result in the corner close to east coast of China
         # TODO if not config.do_schmidt and config.shift_fac > 1.0e-4
         shift_fac = 18
-        self._grid.view[:, :, 0] -= PI / shift_fac
-        tile0_lon = self._grid.data[:, :, 0]
+        self._grid_64.view[:, :, 0] -= PI / shift_fac
+        tile0_lon = self._grid_64.data[:, :, 0]
         tile0_lon[tile0_lon < 0] += 2 * PI
-        self._grid.data[self._np.abs(self._grid.data[:]) < 1e-10] = 0.0
+        self._grid_64.data[self._np.abs(self._grid_64.data[:]) < 1e-10] = 0.0
 
-        self._comm.halo_update(self._grid, n_points=self._halo)
+        self._comm.halo_update(self._grid_64, n_points=self._halo)
 
         fill_corners_2d(
-            self._grid.data, self._grid_indexing, gridtype="B", direction="x"
+            self._grid_64.data, self._grid_indexing, gridtype="B", direction="x"
         )
 
     def _init_agrid(self):
         # Set up lat-lon a-grid, calculate side lengths on a-grid
         lon_agrid, lat_agrid = lon_lat_corner_to_cell_center(
-            self._grid.data[:, :, 0], self._grid.data[:, :, 1], self._np
+            self._grid_64.data[:, :, 0], self._grid_64.data[:, :, 1], self._np
         )
-        self._agrid.data[:-1, :-1, 0], self._agrid.data[:-1, :-1, 1] = (
+        self._agrid_64.data[:-1, :-1, 0], self._agrid_64.data[:-1, :-1, 1] = (
             lon_agrid,
             lat_agrid,
         )
-        self._comm.halo_update(self._agrid, n_points=self._halo)
+        self._comm.halo_update(self._agrid_64, n_points=self._halo)
         fill_corners_2d(
-            self._agrid.data[:, :, 0][:, :, None],
+            self._agrid_64.data[:, :, 0][:, :, None],
             self._grid_indexing,
             gridtype="A",
             direction="x",
         )
         fill_corners_2d(
-            self._agrid.data[:, :, 1][:, :, None],
+            self._agrid_64.data[:, :, 1][:, :, None],
             self._grid_indexing,
             gridtype="A",
             direction="y",
         )
 
     def _compute_dxdy(self):
-        dx = self.quantity_factory.zeros(
+        dx_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "m",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
 
-        dx.view[:, :] = great_circle_distance_along_axis(
-            self._grid.view[:, :, 0],
-            self._grid.view[:, :, 1],
+        dx_64.view[:, :] = great_circle_distance_along_axis(
+            self._grid_64.view[:, :, 0],
+            self._grid_64.view[:, :, 1],
             RADIUS,
             self._np,
             axis=0,
         )
-        dy = self.quantity_factory.zeros(
+        dy_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "m",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        dy.view[:, :] = great_circle_distance_along_axis(
-            self._grid.view[:, :, 0],
-            self._grid.view[:, :, 1],
+        dy_64.view[:, :] = great_circle_distance_along_axis(
+            self._grid_64.view[:, :, 0],
+            self._grid_64.view[:, :, 1],
             RADIUS,
             self._np,
             axis=1,
         )
-        self._comm.vector_halo_update(dx, dy, n_points=self._halo)
+        self._comm.vector_halo_update(dx_64, dy_64, n_points=self._halo)
 
         # at this point the Fortran code copies in the west and east edges from
         # the halo for dy and performs a halo update,
         # to ensure dx and dy mirror across the boundary.
         # Not doing it here at the moment.
-        dx.data[dx.data < 0] *= -1
-        dy.data[dy.data < 0] *= -1
+        dx_64.data[dx_64.data < 0] *= -1
+        dy_64.data[dy_64.data < 0] *= -1
         fill_corners_dgrid(
-            dx.data[:, :, None],
-            dy.data[:, :, None],
+            dx_64.data[:, :, None],
+            dy_64.data[:, :, None],
             self._grid_indexing,
             vector=False,
         )
+
+        dx = quantity_cast_to_model_float(self.quantity_factory, dx_64)
+        dy = quantity_cast_to_model_float(self.quantity_factory, dy_64)
+
         return dx, dy
 
     def _compute_dxdy_agrid(self):
 
-        dx_agrid = self.quantity_factory.zeros(
+        dx_agrid_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "m",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        dy_agrid = self.quantity_factory.zeros(
+        dy_agrid_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "m",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        lon, lat = self._grid.data[:, :, 0], self._grid.data[:, :, 1]
+        lon, lat = self._grid_64.data[:, :, 0], self._grid_64.data[:, :, 1]
         lon_y_center, lat_y_center = lon_lat_midpoint(
             lon[:, :-1], lon[:, 1:], lat[:, :-1], lat[:, 1:], self._np
         )
@@ -1718,33 +1756,39 @@ class MetricTerms:
             vector=False,
         )
 
-        dx_agrid.data[:-1, :-1] = dx_agrid_tmp
-        dy_agrid.data[:-1, :-1] = dy_agrid_tmp
-        self._comm.vector_halo_update(dx_agrid, dy_agrid, n_points=self._halo)
+        dx_agrid_64.data[:-1, :-1] = dx_agrid_tmp
+        dy_agrid_64.data[:-1, :-1] = dy_agrid_tmp
+        self._comm.vector_halo_update(dx_agrid_64, dy_agrid_64, n_points=self._halo)
 
         # at this point the Fortran code copies in the west and east edges from
         # the halo for dy and performs a halo update,
         # to ensure dx and dy mirror across the boundary.
         # Not doing it here at the moment.
-        dx_agrid.data[dx_agrid.data < 0] *= -1
-        dy_agrid.data[dy_agrid.data < 0] *= -1
+        dx_agrid_64.data[dx_agrid_64.data < 0] *= -1
+        dy_agrid_64.data[dy_agrid_64.data < 0] *= -1
+
+        dx_agrid = quantity_cast_to_model_float(self.quantity_factory, dx_agrid_64)
+        dy_agrid = quantity_cast_to_model_float(self.quantity_factory, dy_agrid_64)
+
         return dx_agrid, dy_agrid
 
     def _compute_dxdy_center(self):
-        dx_center = self.quantity_factory.zeros(
+        dx_center_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "m",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        dy_center = self.quantity_factory.zeros(
+        dy_center_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "m",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
 
         lon_agrid, lat_agrid = (
-            self._agrid.data[:-1, :-1, 0],
-            self._agrid.data[:-1, :-1, 1],
+            self._agrid_64.data[:-1, :-1, 0],
+            self._agrid_64.data[:-1, :-1, 1],
         )
         dx_center_tmp = great_circle_distance_along_axis(
             lon_agrid, lat_agrid, RADIUS, self._np, axis=0
@@ -1755,19 +1799,19 @@ class MetricTerms:
         # copying the second-to-last values to the last values is what the Fortran
         # code does, but is this correct/valid?
         # Maybe we want to change this to use halo updates?
-        dx_center.data[1:-1, :-1] = dx_center_tmp
-        dx_center.data[0, :-1] = dx_center_tmp[0, :]
-        dx_center.data[-1, :-1] = dx_center_tmp[-1, :]
+        dx_center_64.data[1:-1, :-1] = dx_center_tmp
+        dx_center_64.data[0, :-1] = dx_center_tmp[0, :]
+        dx_center_64.data[-1, :-1] = dx_center_tmp[-1, :]
 
-        dy_center.data[:-1, 1:-1] = dy_center_tmp
-        dy_center.data[:-1, 0] = dy_center_tmp[:, 0]
-        dy_center.data[:-1, -1] = dy_center_tmp[:, -1]
+        dy_center_64.data[:-1, 1:-1] = dy_center_tmp
+        dy_center_64.data[:-1, 0] = dy_center_tmp[:, 0]
+        dy_center_64.data[:-1, -1] = dy_center_tmp[:, -1]
 
         set_tile_border_dxc(
             self._dgrid_xyz[3:-3, 3:-3, :],
             self._agrid_xyz[3:-3, 3:-3, :],
             RADIUS,
-            dx_center.data[3:-3, 3:-4],
+            dx_center_64.data[3:-3, 3:-4],
             self._tile_partitioner,
             self._rank,
             self._np,
@@ -1776,63 +1820,69 @@ class MetricTerms:
             self._dgrid_xyz[3:-3, 3:-3, :],
             self._agrid_xyz[3:-3, 3:-3, :],
             RADIUS,
-            dy_center.data[3:-4, 3:-3],
+            dy_center_64.data[3:-4, 3:-3],
             self._tile_partitioner,
             self._rank,
             self._np,
         )
-        self._comm.vector_halo_update(dx_center, dy_center, n_points=self._halo)
+        self._comm.vector_halo_update(dx_center_64, dy_center_64, n_points=self._halo)
 
         # TODO: Add support for unsigned vector halo updates
         # instead of handling ad-hoc here
-        dx_center.data[dx_center.data < 0] *= -1
-        dy_center.data[dy_center.data < 0] *= -1
+        dx_center_64.data[dx_center_64.data < 0] *= -1
+        dy_center_64.data[dy_center_64.data < 0] *= -1
 
         # TODO: fix issue with interface dimensions causing validation errors
         fill_corners_cgrid(
-            dx_center.data[:, :, None],
-            dy_center.data[:, :, None],
+            dx_center_64.data[:, :, None],
+            dy_center_64.data[:, :, None],
             self._grid_indexing,
             vector=False,
         )
 
+        dx_center = quantity_cast_to_model_float(self.quantity_factory, dx_center_64)
+        dy_center = quantity_cast_to_model_float(self.quantity_factory, dy_center_64)
+
         return dx_center, dy_center
 
     def _compute_area(self):
-        area = self.quantity_factory.zeros(
+        area_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "m^2",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        area.data[:, :] = -1.0e8
+        area_64.data[:, :] = -1.0e8
 
-        area.data[3:-4, 3:-4] = get_area(
-            self._grid.data[3:-3, 3:-3, 0],
-            self._grid.data[3:-3, 3:-3, 1],
+        area_64.data[3:-4, 3:-4] = get_area(
+            self._grid_64.data[3:-3, 3:-3, 0],
+            self._grid_64.data[3:-3, 3:-3, 1],
             RADIUS,
             self._np,
         )
-        self._comm.halo_update(area, n_points=self._halo)
-        return area
+        self._comm.halo_update(area_64, n_points=self._halo)
+
+        return quantity_cast_to_model_float(self.quantity_factory, area_64)
 
     def _compute_area_c(self):
-        area_cgrid = self.quantity_factory.zeros(
+        area_cgrid_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "m^2",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        area_cgrid.data[3:-3, 3:-3] = get_area(
-            self._agrid.data[2:-3, 2:-3, 0],
-            self._agrid.data[2:-3, 2:-3, 1],
+        area_cgrid_64.data[3:-3, 3:-3] = get_area(
+            self._agrid_64.data[2:-3, 2:-3, 0],
+            self._agrid_64.data[2:-3, 2:-3, 1],
             RADIUS,
             self._np,
         )
         # TODO -- this does not seem to matter? running with or without does
         # not change whether it validates
         set_corner_area_to_triangle_area(
-            lon=self._agrid.data[2:-3, 2:-3, 0],
-            lat=self._agrid.data[2:-3, 2:-3, 1],
-            area=area_cgrid.data[3:-3, 3:-3],
+            lon=self._agrid_64.data[2:-3, 2:-3, 0],
+            lat=self._agrid_64.data[2:-3, 2:-3, 1],
+            area=area_cgrid_64.data[3:-3, 3:-3],
             tile_partitioner=self._tile_partitioner,
             rank=self._rank,
             radius=RADIUS,
@@ -1843,20 +1893,20 @@ class MetricTerms:
             self._dgrid_xyz[2:-2, 2:-2, :],
             self._agrid_xyz[2:-2, 2:-2, :],
             RADIUS,
-            area_cgrid.data[3:-3, 3:-3],
+            area_cgrid_64.data[3:-3, 3:-3],
             self._tile_partitioner,
             self._rank,
             self._np,
         )
-        self._comm.halo_update(area_cgrid, n_points=self._halo)
+        self._comm.halo_update(area_cgrid_64, n_points=self._halo)
 
         fill_corners_2d(
-            area_cgrid.data[:, :, None],
+            area_cgrid_64.data[:, :, None],
             self._grid_indexing,
             gridtype="B",
             direction="x",
         )
-        return area_cgrid
+        return quantity_cast_to_model_float(self.quantity_factory, area_cgrid_64)
 
     def _set_hybrid_pressure_coefficients(self):
         ptop = self.quantity_factory.zeros(
@@ -1881,19 +1931,21 @@ class MetricTerms:
         return ptop, ak, bk
 
     def _calculate_center_vectors(self):
-        ec1 = self.quantity_factory.zeros(
+        ec1_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        ec2 = self.quantity_factory.zeros(
+        ec2_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        ec1.data[:] = self._np.nan
-        ec2.data[:] = self._np.nan
-        ec1.data[:-1, :-1, :3], ec2.data[:-1, :-1, :3] = get_center_vector(
+        ec1_64.data[:] = self._np.nan
+        ec2_64.data[:] = self._np.nan
+        ec1_64.data[:-1, :-1, :3], ec2_64.data[:-1, :-1, :3] = get_center_vector(
             self._dgrid_xyz,
             self._grid_type,
             self._halo,
@@ -1901,22 +1953,27 @@ class MetricTerms:
             self._rank,
             self._np,
         )
+
+        ec1 = quantity_cast_to_model_float(self.quantity_factory, ec1_64)
+        ec2 = quantity_cast_to_model_float(self.quantity_factory, ec2_64)
         return ec1, ec2
 
     def _calculate_vectors_west(self):
-        ew1 = self.quantity_factory.zeros(
+        ew1_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        ew2 = self.quantity_factory.zeros(
+        ew2_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        ew1.data[:] = self._np.nan
-        ew2.data[:] = self._np.nan
-        ew1.data[1:-1, :-1, :3], ew2.data[1:-1, :-1, :3] = calc_unit_vector_west(
+        ew1_64.data[:] = self._np.nan
+        ew2_64.data[:] = self._np.nan
+        ew1_64.data[1:-1, :-1, :3], ew2_64.data[1:-1, :-1, :3] = calc_unit_vector_west(
             self._dgrid_xyz,
             self._agrid_xyz,
             self._grid_type,
@@ -1925,22 +1982,25 @@ class MetricTerms:
             self._rank,
             self._np,
         )
+
+        ew1 = quantity_cast_to_model_float(self.quantity_factory, ew1_64)
+        ew2 = quantity_cast_to_model_float(self.quantity_factory, ew2_64)
         return ew1, ew2
 
     def _calculate_vectors_south(self):
-        es1 = self.quantity_factory.zeros(
+        es1_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            allow_mismatch_float_precision=True,
         )
-        es2 = self.quantity_factory.zeros(
+        es2_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            allow_mismatch_float_precision=True,
         )
-        es1.data[:] = self._np.nan
-        es2.data[:] = self._np.nan
-        es1.data[:-1, 1:-1, :3], es2.data[:-1, 1:-1, :3] = calc_unit_vector_south(
+        es1_64.data[:] = self._np.nan
+        es2_64.data[:] = self._np.nan
+        es1_64.data[:-1, 1:-1, :3], es2_64.data[:-1, 1:-1, :3] = calc_unit_vector_south(
             self._dgrid_xyz,
             self._agrid_xyz,
             self._grid_type,
@@ -1949,76 +2009,90 @@ class MetricTerms:
             self._rank,
             self._np,
         )
+
+        es1 = quantity_cast_to_model_float(self.quantity_factory, es1_64)
+        es2 = quantity_cast_to_model_float(self.quantity_factory, es2_64)
         return es1, es2
 
     def _calculate_more_trig_terms(self, cos_sg, sin_sg):
-        cosa_u = self.quantity_factory.zeros(
+        cosa_u_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        cosa_v = self.quantity_factory.zeros(
+        cosa_v_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        cosa_s = self.quantity_factory.zeros(
+        cosa_s_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        sina_u = self.quantity_factory.zeros(
+        sina_u_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        sina_v = self.quantity_factory.zeros(
+        sina_v_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        rsin_u = self.quantity_factory.zeros(
+        rsin_u_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        rsin_v = self.quantity_factory.zeros(
+        rsin_v_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        rsina = self.quantity_factory.zeros(
+        rsina_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        rsin2 = self.quantity_factory.zeros(
+        rsin2_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        cosa = self.quantity_factory.zeros(
+        cosa_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        sina = self.quantity_factory.zeros(
+        sina_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         (
-            cosa.data[:, :],
-            sina.data[:, :],
-            cosa_u.data[:, :-1],
-            cosa_v.data[:-1, :],
-            cosa_s.data[:-1, :-1],
-            sina_u.data[:, :-1],
-            sina_v.data[:-1, :],
-            rsin_u.data[:, :-1],
-            rsin_v.data[:-1, :],
-            rsina.data[self._halo : -self._halo, self._halo : -self._halo],
-            rsin2.data[:-1, :-1],
+            cosa_64.data[:, :],
+            sina_64.data[:, :],
+            cosa_u_64.data[:, :-1],
+            cosa_v_64.data[:-1, :],
+            cosa_s_64.data[:-1, :-1],
+            sina_u_64.data[:, :-1],
+            sina_v_64.data[:-1, :],
+            rsin_u_64.data[:, :-1],
+            rsin_v_64.data[:-1, :],
+            rsina_64.data[self._halo : -self._halo, self._halo : -self._halo],
+            rsin2_64.data[:-1, :-1],
         ) = calculate_trig_uv(
             self._dgrid_xyz,
             cos_sg,
@@ -2029,75 +2103,86 @@ class MetricTerms:
             self._np,
         )
         return (
-            cosa,
-            sina,
-            cosa_u,
-            cosa_v,
-            cosa_s,
-            sina_u,
-            sina_v,
-            rsin_u,
-            rsin_v,
-            rsina,
-            rsin2,
+            quantity_cast_to_model_float(self.quantity_factory, cosa_64),
+            quantity_cast_to_model_float(self.quantity_factory, sina_64),
+            quantity_cast_to_model_float(self.quantity_factory, cosa_u_64),
+            quantity_cast_to_model_float(self.quantity_factory, cosa_v_64),
+            quantity_cast_to_model_float(self.quantity_factory, cosa_s_64),
+            quantity_cast_to_model_float(self.quantity_factory, sina_u_64),
+            quantity_cast_to_model_float(self.quantity_factory, sina_v_64),
+            quantity_cast_to_model_float(self.quantity_factory, rsin_u_64),
+            quantity_cast_to_model_float(self.quantity_factory, rsin_v_64),
+            quantity_cast_to_model_float(self.quantity_factory, rsina_64),
+            quantity_cast_to_model_float(self.quantity_factory, rsin2_64),
         )
 
     def _init_cell_trigonometry(self):
 
-        self._cosa_u = self.quantity_factory.zeros(
+        cosa_u_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._cosa_v = self.quantity_factory.zeros(
+        cosa_v_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._cosa_s = self.quantity_factory.zeros(
+        cosa_s_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._sina_u = self.quantity_factory.zeros(
+        sina_u_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._sina_v = self.quantity_factory.zeros(
+        sina_v_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._rsin_u = self.quantity_factory.zeros(
+        rsin_u_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._rsin_v = self.quantity_factory.zeros(
+        rsin_v_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._rsina = self.quantity_factory.zeros(
+        rsina_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._rsin2 = self.quantity_factory.zeros(
+        rsin2_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._cosa = self.quantity_factory.zeros(
+        cosa_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._sina = self.quantity_factory.zeros(
+        sina_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
 
         # This section calculates the cos_sg and sin_sg terms, which describe the
@@ -2121,17 +2206,17 @@ class MetricTerms:
         )
 
         (
-            self._cosa.data[:, :],
-            self._sina.data[:, :],
-            self._cosa_u.data[:, :-1],
-            self._cosa_v.data[:-1, :],
-            self._cosa_s.data[:-1, :-1],
-            self._sina_u.data[:, :-1],
-            self._sina_v.data[:-1, :],
-            self._rsin_u.data[:, :-1],
-            self._rsin_v.data[:-1, :],
-            self._rsina.data[self._halo : -self._halo, self._halo : -self._halo],
-            self._rsin2.data[:-1, :-1],
+            cosa_64.data[:, :],
+            sina_64.data[:, :],
+            cosa_u_64.data[:, :-1],
+            cosa_v_64.data[:-1, :],
+            cosa_s_64.data[:-1, :-1],
+            sina_u_64.data[:, :-1],
+            sina_v_64.data[:-1, :],
+            rsin_u_64.data[:, :-1],
+            rsin_v_64.data[:-1, :],
+            rsina_64.data[self._halo : -self._halo, self._halo : -self._halo],
+            rsin2_64.data[:-1, :-1],
         ) = calculate_trig_uv(
             self._dgrid_xyz,
             cos_sg,
@@ -2151,90 +2236,156 @@ class MetricTerms:
             supergrid_trig[f"cos_sg{i}"] = self.quantity_factory.zeros(
                 [util.X_DIM, util.Y_DIM],
                 "",
-                dtype=Float,
+                dtype=np.float64,
+                allow_mismatch_float_precision=True,
             )
             supergrid_trig[f"cos_sg{i}"].data[:-1, :-1] = cos_sg[:, :, i - 1]
             supergrid_trig[f"sin_sg{i}"] = self.quantity_factory.zeros(
                 [util.X_DIM, util.Y_DIM],
                 "",
-                dtype=Float,
+                dtype=np.float64,
+                allow_mismatch_float_precision=True,
             )
             supergrid_trig[f"sin_sg{i}"].data[:-1, :-1] = sin_sg[:, :, i - 1]
 
-        self._cos_sg1 = supergrid_trig["cos_sg1"]
-        self._cos_sg2 = supergrid_trig["cos_sg2"]
-        self._cos_sg3 = supergrid_trig["cos_sg3"]
-        self._cos_sg4 = supergrid_trig["cos_sg4"]
-        self._cos_sg5 = supergrid_trig["cos_sg5"]
-        self._cos_sg6 = supergrid_trig["cos_sg6"]
-        self._cos_sg7 = supergrid_trig["cos_sg7"]
-        self._cos_sg8 = supergrid_trig["cos_sg8"]
-        self._cos_sg9 = supergrid_trig["cos_sg9"]
-        self._sin_sg1 = supergrid_trig["sin_sg1"]
-        self._sin_sg2 = supergrid_trig["sin_sg2"]
-        self._sin_sg3 = supergrid_trig["sin_sg3"]
-        self._sin_sg4 = supergrid_trig["sin_sg4"]
-        self._sin_sg5 = supergrid_trig["sin_sg5"]
-        self._sin_sg6 = supergrid_trig["sin_sg6"]
-        self._sin_sg7 = supergrid_trig["sin_sg7"]
-        self._sin_sg8 = supergrid_trig["sin_sg8"]
-        self._sin_sg9 = supergrid_trig["sin_sg9"]
+        self._cos_sg1 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg1"]
+        )
+        self._cos_sg2 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg2"]
+        )
+        self._cos_sg3 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg3"]
+        )
+        self._cos_sg4 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg4"]
+        )
+        self._cos_sg5 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg5"]
+        )
+        self._cos_sg6 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg6"]
+        )
+        self._cos_sg7 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg7"]
+        )
+        self._cos_sg8 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg8"]
+        )
+        self._cos_sg9 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["cos_sg9"]
+        )
+        self._sin_sg1 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg1"]
+        )
+        self._sin_sg2 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg2"]
+        )
+        self._sin_sg3 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg3"]
+        )
+        self._sin_sg4 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg4"]
+        )
+        self._sin_sg5 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg5"]
+        )
+        self._sin_sg6 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg6"]
+        )
+        self._sin_sg7 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg7"]
+        )
+        self._sin_sg8 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg8"]
+        )
+        self._sin_sg9 = quantity_cast_to_model_float(
+            self.quantity_factory, supergrid_trig["sin_sg9"]
+        )
+
+        # Casting
+        self._cosa_u = quantity_cast_to_model_float(self.quantity_factory, cosa_u_64)
+        self._cosa_v = quantity_cast_to_model_float(self.quantity_factory, cosa_v_64)
+        self._cosa_s = quantity_cast_to_model_float(self.quantity_factory, cosa_s_64)
+        self._sina_u = quantity_cast_to_model_float(self.quantity_factory, sina_u_64)
+        self._sina_v = quantity_cast_to_model_float(self.quantity_factory, sina_v_64)
+        self._rsin_u = quantity_cast_to_model_float(self.quantity_factory, rsin_u_64)
+        self._rsin_v = quantity_cast_to_model_float(self.quantity_factory, rsin_v_64)
+        self._rsina = quantity_cast_to_model_float(self.quantity_factory, rsina_64)
+        self._rsin2 = quantity_cast_to_model_float(self.quantity_factory, rsin2_64)
+        self._cosa = quantity_cast_to_model_float(self.quantity_factory, cosa_64)
+        self._sina = quantity_cast_to_model_float(self.quantity_factory, sina_64)
 
     def _calculate_derived_trig_terms_for_testing(self):
         """
         As _calculate_derived_trig_terms_for_testing but updates trig attributes
         in-place without the halo updates. For use only in validation tests.
         """
-        self._cosa_u = self.quantity_factory.zeros(
+        cosa_u_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._cosa_v = self.quantity_factory.zeros(
+        cosa_v_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._cosa_s = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
-        self._sina_u = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM],
-            "",
-            dtype=Float,
-        )
-        self._sina_v = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM],
-            "",
-            dtype=Float,
-        )
-        self._rsin_u = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_DIM],
-            "",
-            dtype=Float,
-        )
-        self._rsin_v = self.quantity_factory.zeros(
-            [util.X_DIM, util.Y_INTERFACE_DIM],
-            "",
-            dtype=Float,
-        )
-        self._rsina = self.quantity_factory.zeros(
-            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
-            "",
-            dtype=Float,
-        )
-        self._rsin2 = self.quantity_factory.zeros(
+        cosa_s_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._cosa = self.quantity_factory.zeros(
+        sina_u_64 = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
+        )
+        sina_v_64 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
+        )
+        rsin_u_64 = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_DIM],
+            "",
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
+        )
+        rsin_v_64 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
+        )
+        rsina_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        self._sina = self.quantity_factory.zeros(
+        rsin2_64 = self.quantity_factory.zeros(
+            [util.X_DIM, util.Y_DIM],
+            "",
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
+        )
+        cosa_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
+        )
+        sina_64 = self.quantity_factory.zeros(
+            [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
+            "",
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
 
         cos_sg = self._np.array(
@@ -2265,17 +2416,17 @@ class MetricTerms:
         ).transpose([1, 2, 0])
 
         (
-            self._cosa.data[:, :],
-            self._sina.data[:, :],
-            self._cosa_u.data[:, :-1],
-            self._cosa_v.data[:-1, :],
-            self._cosa_s.data[:-1, :-1],
-            self._sina_u.data[:, :-1],
-            self._sina_v.data[:-1, :],
-            self._rsin_u.data[:, :-1],
-            self._rsin_v.data[:-1, :],
-            self._rsina.data[self._halo : -self._halo, self._halo : -self._halo],
-            self._rsin2.data[:-1, :-1],
+            cosa_64.data[:, :],
+            sina_64.data[:, :],
+            cosa_u_64.data[:, :-1],
+            cosa_v_64.data[:-1, :],
+            cosa_s_64.data[:-1, :-1],
+            sina_u_64.data[:, :-1],
+            sina_v_64.data[:-1, :],
+            rsin_u_64.data[:, :-1],
+            rsin_v_64.data[:-1, :],
+            rsina_64.data[self._halo : -self._halo, self._halo : -self._halo],
+            rsin2_64.data[:-1, :-1],
         ) = calculate_trig_uv(
             self._dgrid_xyz,
             cos_sg,
@@ -2286,64 +2437,92 @@ class MetricTerms:
             self._np,
         )
 
+        self._cosa = quantity_cast_to_model_float(self.quantity_factory, cosa_64)
+        self._sina = quantity_cast_to_model_float(self.quantity_factory, sina_64)
+        self._cosa_u = quantity_cast_to_model_float(self.quantity_factory, cosa_u_64)
+        self._cosa_v = quantity_cast_to_model_float(self.quantity_factory, cosa_v_64)
+        self._cosa_s = quantity_cast_to_model_float(self.quantity_factory, cosa_s_64)
+        self._sina_u = quantity_cast_to_model_float(self.quantity_factory, sina_u_64)
+        self._sina_v = quantity_cast_to_model_float(self.quantity_factory, sina_v_64)
+        self._rsin_u = quantity_cast_to_model_float(self.quantity_factory, rsin_u_64)
+        self._rsin_v = quantity_cast_to_model_float(self.quantity_factory, rsin_v_64)
+        self._rsina = quantity_cast_to_model_float(self.quantity_factory, rsina_64)
+        self._rsin2 = quantity_cast_to_model_float(self.quantity_factory, rsin2_64)
+
     def _calculate_latlon_momentum_correction(self):
-        l2c_v = self.quantity_factory.zeros(
+        l2c_v_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
             dtype=Float,
+            allow_mismatch_float_precision=True,
         )
-        l2c_u = self.quantity_factory.zeros(
+        l2c_u_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
             dtype=Float,
+            allow_mismatch_float_precision=True,
         )
         (
-            l2c_v.data[self._halo : -self._halo, self._halo : -self._halo - 1],
-            l2c_u.data[self._halo : -self._halo - 1, self._halo : -self._halo],
-        ) = calculate_l2c_vu(self._grid.data[:], self._halo, self._np)
+            l2c_v_64.data[self._halo : -self._halo, self._halo : -self._halo - 1],
+            l2c_u_64.data[self._halo : -self._halo - 1, self._halo : -self._halo],
+        ) = calculate_l2c_vu(self._grid_64.data[:], self._halo, self._np)
+
+        l2c_u = quantity_cast_to_model_float(self.quantity_factory, l2c_u_64)
+        l2c_v = quantity_cast_to_model_float(self.quantity_factory, l2c_v_64)
+
         return l2c_v, l2c_u
 
     def _calculate_xy_unit_vectors(self):
-        ee1 = self.quantity_factory.zeros(
+        ee1_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        ee2 = self.quantity_factory.zeros(
+        ee2_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        ee1.data[:] = self._np.nan
-        ee2.data[:] = self._np.nan
+        ee1_64.data[:] = self._np.nan
+        ee2_64.data[:] = self._np.nan
         (
-            ee1.data[self._halo : -self._halo, self._halo : -self._halo, :],
-            ee2.data[self._halo : -self._halo, self._halo : -self._halo, :],
+            ee1_64.data[self._halo : -self._halo, self._halo : -self._halo, :],
+            ee2_64.data[self._halo : -self._halo, self._halo : -self._halo, :],
         ) = calculate_xy_unit_vectors(
             self._dgrid_xyz, self._halo, self._tile_partitioner, self._rank, self._np
         )
+
+        ee1 = quantity_cast_to_model_float(self.quantity_factory, ee1_64)
+        ee2 = quantity_cast_to_model_float(self.quantity_factory, ee2_64)
+
         return ee1, ee2
 
     def _calculate_divg_del6(self):
-        del6_u = self.quantity_factory.zeros(
+        del6_u_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        del6_v = self.quantity_factory.zeros(
+        del6_v_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        divg_u = self.quantity_factory.zeros(
+        divg_u_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        divg_v = self.quantity_factory.zeros(
+        divg_v_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         sin_sg = [
             self.sin_sg1.data[:-1, :-1],
@@ -2354,10 +2533,10 @@ class MetricTerms:
         ]
         sin_sg = self._np.array(sin_sg).transpose(1, 2, 0)
         (
-            divg_u.data[:-1, :],
-            divg_v.data[:, :-1],
-            del6_u.data[:-1, :],
-            del6_v.data[:, :-1],
+            divg_u_64.data[:-1, :],
+            divg_v_64.data[:, :-1],
+            del6_u_64.data[:-1, :],
+            del6_v_64.data[:, :-1],
         ) = calculate_divg_del6(
             sin_sg,
             self.sina_u.data[:, :-1],
@@ -2371,14 +2550,20 @@ class MetricTerms:
             self._rank,
         )
         if self._grid_type < 3:
-            self._comm.vector_halo_update(divg_v, divg_u, n_points=self._halo)
-            self._comm.vector_halo_update(del6_v, del6_u, n_points=self._halo)
+            self._comm.vector_halo_update(divg_v_64, divg_u_64, n_points=self._halo)
+            self._comm.vector_halo_update(del6_v_64, del6_u_64, n_points=self._halo)
             # TODO: Add support for unsigned vector halo updates
             # instead of handling ad-hoc here
-            divg_v.data[divg_v.data < 0] *= -1
-            divg_u.data[divg_u.data < 0] *= -1
-            del6_v.data[del6_v.data < 0] *= -1
-            del6_u.data[del6_u.data < 0] *= -1
+            divg_v_64.data[divg_v_64.data < 0] *= -1
+            divg_u_64.data[divg_u_64.data < 0] *= -1
+            del6_v_64.data[del6_v_64.data < 0] *= -1
+            del6_u_64.data[del6_u_64.data < 0] *= -1
+
+        divg_v = quantity_cast_to_model_float(self.quantity_factory, divg_v_64)
+        divg_u = quantity_cast_to_model_float(self.quantity_factory, divg_u_64)
+        del6_v = quantity_cast_to_model_float(self.quantity_factory, del6_v_64)
+        del6_u = quantity_cast_to_model_float(self.quantity_factory, del6_u_64)
+
         return del6_u, del6_v, divg_u, divg_v
 
     def _calculate_divg_del6_nohalos_for_testing(self):
@@ -2386,25 +2571,29 @@ class MetricTerms:
         As _calculate_divg_del6 but updates self.divg and self.del6 attributes
         in-place without the halo updates. For use only in validation tests.
         """
-        del6_u = self.quantity_factory.zeros(
+        del6_u_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        del6_v = self.quantity_factory.zeros(
+        del6_v_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        divg_u = self.quantity_factory.zeros(
+        divg_u_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        divg_v = self.quantity_factory.zeros(
+        divg_v_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         sin_sg = [
             self.sin_sg1.data[:-1, :-1],
@@ -2415,10 +2604,10 @@ class MetricTerms:
         ]
         sin_sg = self._np.array(sin_sg).transpose(1, 2, 0)
         (
-            divg_u.data[:-1, :],
-            divg_v.data[:, :-1],
-            del6_u.data[:-1, :],
-            del6_v.data[:, :-1],
+            divg_u_64.data[:-1, :],
+            divg_v_64.data[:, :-1],
+            del6_u_64.data[:-1, :],
+            del6_v_64.data[:, :-1],
         ) = calculate_divg_del6(
             sin_sg,
             self.sina_u.data[:, :-1],
@@ -2431,54 +2620,64 @@ class MetricTerms:
             self._tile_partitioner,
             self._rank,
         )
-        self._divg_v = divg_v
-        self._divg_u = divg_u
-        self._del6_v = del6_v
-        self._del6_u = del6_u
+        self._divg_v = quantity_cast_to_model_float(self.quantity_factory, divg_v_64)
+        self._divg_u = quantity_cast_to_model_float(self.quantity_factory, divg_u_64)
+        self._del6_v = quantity_cast_to_model_float(self.quantity_factory, del6_v_64)
+        self._del6_u = quantity_cast_to_model_float(self.quantity_factory, del6_u_64)
 
     def _calculate_unit_vectors_lonlat(self):
-        vlon = self.quantity_factory.zeros(
+        vlon_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        vlat = self.quantity_factory.zeros(
+        vlat_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
 
-        vlon.data[:-1, :-1], vlat.data[:-1, :-1] = unit_vector_lonlat(
-            self._agrid.data[:-1, :-1], self._np
+        vlon_64.data[:-1, :-1], vlat_64.data[:-1, :-1] = unit_vector_lonlat(
+            self._agrid_64.data[:-1, :-1], self._np
         )
+
+        vlon = quantity_cast_to_model_float(self.quantity_factory, vlon_64)
+        vlat = quantity_cast_to_model_float(self.quantity_factory, vlat_64)
+
         return vlon, vlat
 
     def _calculate_grid_z(self):
-        z11 = self.quantity_factory.zeros(
+        z11_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        z12 = self.quantity_factory.zeros(
+        z12_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        z21 = self.quantity_factory.zeros(
+        z21_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        z22 = self.quantity_factory.zeros(
+        z22_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         (
-            z11.data[:-1, :-1],
-            z12.data[:-1, :-1],
-            z21.data[:-1, :-1],
-            z22.data[:-1, :-1],
+            z11_64.data[:-1, :-1],
+            z12_64.data[:-1, :-1],
+            z21_64.data[:-1, :-1],
+            z22_64.data[:-1, :-1],
         ) = calculate_grid_z(
             self.ec1.data[:-1, :-1],
             self.ec2.data[:-1, :-1],
@@ -2486,34 +2685,44 @@ class MetricTerms:
             self.vlat.data[:-1, :-1],
             self._np,
         )
+
+        z11 = quantity_cast_to_model_float(self.quantity_factory, z11_64)
+        z12 = quantity_cast_to_model_float(self.quantity_factory, z12_64)
+        z21 = quantity_cast_to_model_float(self.quantity_factory, z21_64)
+        z22 = quantity_cast_to_model_float(self.quantity_factory, z22_64)
+
         return z11, z12, z21, z22
 
     def _calculate_grid_a(self):
-        a11 = self.quantity_factory.zeros(
+        a11_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        a12 = self.quantity_factory.zeros(
+        a12_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        a21 = self.quantity_factory.zeros(
+        a21_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        a22 = self.quantity_factory.zeros(
+        a22_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         (
-            a11.data[:-1, :-1],
-            a12.data[:-1, :-1],
-            a21.data[:-1, :-1],
-            a22.data[:-1, :-1],
+            a11_64.data[:-1, :-1],
+            a12_64.data[:-1, :-1],
+            a21_64.data[:-1, :-1],
+            a22_64.data[:-1, :-1],
         ) = calculate_grid_a(
             self.z11.data[:-1, :-1],
             self.z12.data[:-1, :-1],
@@ -2521,35 +2730,45 @@ class MetricTerms:
             self.z22.data[:-1, :-1],
             self.sin_sg5.data[:-1, :-1],
         )
+
+        a11 = quantity_cast_to_model_float(self.quantity_factory, a11_64)
+        a12 = quantity_cast_to_model_float(self.quantity_factory, a12_64)
+        a21 = quantity_cast_to_model_float(self.quantity_factory, a21_64)
+        a22 = quantity_cast_to_model_float(self.quantity_factory, a22_64)
+
         return a11, a12, a21, a22
 
     def _calculate_edge_factors(self):
         nhalo = self._halo
-        edge_s = self.quantity_factory.zeros(
+        edge_s_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        edge_n = self.quantity_factory.zeros(
+        edge_n_64 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        edge_e = self.quantity_factory.zeros(
+        edge_e_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        edge_w = self.quantity_factory.zeros(
+        edge_w_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         (
-            edge_w.data[:, nhalo:-nhalo],
-            edge_e.data[:, nhalo:-nhalo],
-            edge_s.data[nhalo:-nhalo],
-            edge_n.data[nhalo:-nhalo],
+            edge_w_64.data[:, nhalo:-nhalo],
+            edge_e_64.data[:, nhalo:-nhalo],
+            edge_s_64.data[nhalo:-nhalo],
+            edge_n_64.data[nhalo:-nhalo],
         ) = edge_factors(
             self.gridvar,
             self.agrid.data[:-1, :-1],
@@ -2560,34 +2779,44 @@ class MetricTerms:
             RADIUS,
             self._np,
         )
+
+        edge_w = quantity_cast_to_model_float(self.quantity_factory, edge_w_64)
+        edge_e = quantity_cast_to_model_float(self.quantity_factory, edge_e_64)
+        edge_s = quantity_cast_to_model_float(self.quantity_factory, edge_s_64)
+        edge_n = quantity_cast_to_model_float(self.quantity_factory, edge_n_64)
+
         return edge_w, edge_e, edge_s, edge_n
 
     def _calculate_edge_a2c_vect_factors(self):
-        edge_vect_s = self.quantity_factory.zeros(
+        edge_vect_s_64 = self.quantity_factory.zeros(
             [util.X_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        edge_vect_n = self.quantity_factory.zeros(
+        edge_vect_n_64 = self.quantity_factory.zeros(
             [util.X_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        edge_vect_e = self.quantity_factory.zeros(
+        edge_vect_e_64 = self.quantity_factory.zeros(
             [util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        edge_vect_w = self.quantity_factory.zeros(
+        edge_vect_w_64 = self.quantity_factory.zeros(
             [util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         (
-            edge_vect_w.data[:-1],
-            edge_vect_e.data[:-1],
-            edge_vect_s.data[:-1],
-            edge_vect_n.data[:-1],
+            edge_vect_w_64.data[:-1],
+            edge_vect_e_64.data[:-1],
+            edge_vect_s_64.data[:-1],
+            edge_vect_n_64.data[:-1],
         ) = efactor_a2c_v(
             self.gridvar,
             self.agrid.data[:-1, :-1],
@@ -2598,27 +2827,49 @@ class MetricTerms:
             RADIUS,
             self._np,
         )
+
+        edge_vect_w = quantity_cast_to_model_float(
+            self.quantity_factory, edge_vect_w_64
+        )
+        edge_vect_e = quantity_cast_to_model_float(
+            self.quantity_factory, edge_vect_e_64
+        )
+        edge_vect_s = quantity_cast_to_model_float(
+            self.quantity_factory, edge_vect_s_64
+        )
+        edge_vect_n = quantity_cast_to_model_float(
+            self.quantity_factory, edge_vect_n_64
+        )
         return edge_vect_w, edge_vect_e, edge_vect_s, edge_vect_n
 
     def _calculate_2d_edge_a2c_vect_factors(self):
-        edge_vect_e_2d = self.quantity_factory.zeros(
+        edge_vect_e_2d_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
-        edge_vect_w_2d = self.quantity_factory.zeros(
+        edge_vect_w_2d_64 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=Float,
+            dtype=np.float64,
+            allow_mismatch_float_precision=True,
         )
         shape = self.lon.data.shape
         east_edge_data = self.edge_vect_e_1d.data[self._np.newaxis, ...]
         east_edge_data = self._np.repeat(east_edge_data, shape[0], axis=0)
         west_edge_data = self.edge_vect_w_1d.data[self._np.newaxis, ...]
         west_edge_data = self._np.repeat(west_edge_data, shape[0], axis=0)
-        edge_vect_e_2d.data[:-1, :-1], edge_vect_w_2d.data[:-1, :-1] = (
+        edge_vect_e_2d_64.data[:-1, :-1], edge_vect_w_2d_64.data[:-1, :-1] = (
             east_edge_data[:-1, :-1],
             west_edge_data[:-1, :-1],
+        )
+
+        edge_vect_e_2d = quantity_cast_to_model_float(
+            self.quantity_factory, edge_vect_e_2d_64
+        )
+        edge_vect_w_2d = quantity_cast_to_model_float(
+            self.quantity_factory, edge_vect_w_2d_64
         )
         return edge_vect_e_2d, edge_vect_w_2d
 

--- a/util/pace/util/grid/generation.py
+++ b/util/pace/util/grid/generation.py
@@ -6,6 +6,7 @@ from typing import Tuple
 from pace import util
 from pace.dsl.gt4py_utils import asarray
 from pace.dsl.stencil import GridIndexing
+from pace.dsl.typing import Float
 from pace.stencils.corners import (
     fill_corners_2d,
     fill_corners_agrid,
@@ -237,7 +238,7 @@ class MetricTerms:
         self._grid = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         npx, npy, ndims = self._tile_partitioner.global_extent(self._grid)
         self._npx = npx
@@ -246,7 +247,7 @@ class MetricTerms:
         self._agrid = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.LON_OR_LAT_DIM],
             "radians",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._np = self._grid.np
         self._dx = None
@@ -1480,17 +1481,17 @@ class MetricTerms:
         grid_mirror_ew = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         grid_mirror_ns = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         grid_mirror_diag = self.quantity_factory.zeros(
             self._grid_dims,
             "radians",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
 
         local_west_edge = self._tile_partitioner.on_tile_left(self._rank)
@@ -1647,7 +1648,7 @@ class MetricTerms:
         dx = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "m",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
 
         dx.view[:, :] = great_circle_distance_along_axis(
@@ -1660,7 +1661,7 @@ class MetricTerms:
         dy = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "m",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         dy.view[:, :] = great_circle_distance_along_axis(
             self._grid.view[:, :, 0],
@@ -1690,12 +1691,12 @@ class MetricTerms:
         dx_agrid = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "m",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         dy_agrid = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "m",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         lon, lat = self._grid.data[:, :, 0], self._grid.data[:, :, 1]
         lon_y_center, lat_y_center = lon_lat_midpoint(
@@ -1733,12 +1734,12 @@ class MetricTerms:
         dx_center = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "m",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         dy_center = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "m",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
 
         lon_agrid, lat_agrid = (
@@ -1801,7 +1802,7 @@ class MetricTerms:
         area = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "m^2",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         area.data[:, :] = -1.0e8
 
@@ -1818,7 +1819,7 @@ class MetricTerms:
         area_cgrid = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "m^2",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         area_cgrid.data[3:-3, 3:-3] = get_area(
             self._agrid.data[2:-3, 2:-3, 0],
@@ -1861,17 +1862,17 @@ class MetricTerms:
         ptop = self.quantity_factory.zeros(
             [],
             "Pa",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         ak = self.quantity_factory.zeros(
             [util.Z_INTERFACE_DIM],
             "Pa",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         bk = self.quantity_factory.zeros(
             [util.Z_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         pressure_coefficients = set_hybrid_pressure_coefficients(self._npz)
         ptop = pressure_coefficients.ptop
@@ -1883,12 +1884,12 @@ class MetricTerms:
         ec1 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         ec2 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         ec1.data[:] = self._np.nan
         ec2.data[:] = self._np.nan
@@ -1906,12 +1907,12 @@ class MetricTerms:
         ew1 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         ew2 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         ew1.data[:] = self._np.nan
         ew2.data[:] = self._np.nan
@@ -1930,12 +1931,12 @@ class MetricTerms:
         es1 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         es2 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         es1.data[:] = self._np.nan
         es2.data[:] = self._np.nan
@@ -1954,57 +1955,57 @@ class MetricTerms:
         cosa_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         cosa_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         cosa_s = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         sina_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         sina_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         rsin_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         rsin_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         rsina = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         rsin2 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         cosa = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         sina = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         (
             cosa.data[:, :],
@@ -2046,57 +2047,57 @@ class MetricTerms:
         self._cosa_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._cosa_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._cosa_s = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._sina_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._sina_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._rsin_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._rsin_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._rsina = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._rsin2 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._cosa = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._sina = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
 
         # This section calculates the cos_sg and sin_sg terms, which describe the
@@ -2150,13 +2151,13 @@ class MetricTerms:
             supergrid_trig[f"cos_sg{i}"] = self.quantity_factory.zeros(
                 [util.X_DIM, util.Y_DIM],
                 "",
-                dtype=util.pfloat(),
+                dtype=Float,
             )
             supergrid_trig[f"cos_sg{i}"].data[:-1, :-1] = cos_sg[:, :, i - 1]
             supergrid_trig[f"sin_sg{i}"] = self.quantity_factory.zeros(
                 [util.X_DIM, util.Y_DIM],
                 "",
-                dtype=util.pfloat(),
+                dtype=Float,
             )
             supergrid_trig[f"sin_sg{i}"].data[:-1, :-1] = sin_sg[:, :, i - 1]
 
@@ -2187,53 +2188,53 @@ class MetricTerms:
         self._cosa_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._cosa_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._cosa_s = self.quantity_factory.zeros([util.X_DIM, util.Y_DIM], "")
         self._sina_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._sina_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._rsin_u = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._rsin_v = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._rsina = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._rsin2 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._cosa = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         self._sina = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
 
         cos_sg = self._np.array(
@@ -2289,12 +2290,12 @@ class MetricTerms:
         l2c_v = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         l2c_u = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         (
             l2c_v.data[self._halo : -self._halo, self._halo : -self._halo - 1],
@@ -2306,12 +2307,12 @@ class MetricTerms:
         ee1 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         ee2 = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_INTERFACE_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         ee1.data[:] = self._np.nan
         ee2.data[:] = self._np.nan
@@ -2327,22 +2328,22 @@ class MetricTerms:
         del6_u = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         del6_v = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         divg_u = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         divg_v = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         sin_sg = [
             self.sin_sg1.data[:-1, :-1],
@@ -2388,22 +2389,22 @@ class MetricTerms:
         del6_u = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         del6_v = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         divg_u = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         divg_v = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         sin_sg = [
             self.sin_sg1.data[:-1, :-1],
@@ -2439,12 +2440,12 @@ class MetricTerms:
         vlon = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         vlat = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM, self.CARTESIAN_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
 
         vlon.data[:-1, :-1], vlat.data[:-1, :-1] = unit_vector_lonlat(
@@ -2456,22 +2457,22 @@ class MetricTerms:
         z11 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         z12 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         z21 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         z22 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         (
             z11.data[:-1, :-1],
@@ -2491,22 +2492,22 @@ class MetricTerms:
         a11 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         a12 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         a21 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         a22 = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         (
             a11.data[:-1, :-1],
@@ -2527,22 +2528,22 @@ class MetricTerms:
         edge_s = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         edge_n = self.quantity_factory.zeros(
             [util.X_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         edge_e = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         edge_w = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_INTERFACE_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         (
             edge_w.data[:, nhalo:-nhalo],
@@ -2565,22 +2566,22 @@ class MetricTerms:
         edge_vect_s = self.quantity_factory.zeros(
             [util.X_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         edge_vect_n = self.quantity_factory.zeros(
             [util.X_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         edge_vect_e = self.quantity_factory.zeros(
             [util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         edge_vect_w = self.quantity_factory.zeros(
             [util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         (
             edge_vect_w.data[:-1],
@@ -2603,12 +2604,12 @@ class MetricTerms:
         edge_vect_e_2d = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         edge_vect_w_2d = self.quantity_factory.zeros(
             [util.X_DIM, util.Y_DIM],
             "",
-            dtype=util.pfloat(),
+            dtype=Float,
         )
         shape = self.lon.data.shape
         east_edge_data = self.edge_vect_e_1d.data[self._np.newaxis, ...]

--- a/util/pace/util/halo_data_transformer.py
+++ b/util/pace/util/halo_data_transformer.py
@@ -9,15 +9,19 @@ import numpy as np
 from ._optional_imports import cupy as cp
 from .buffer import Buffer
 from .cuda_kernels import (
+    pack_scalar_f32_kernel,
     pack_scalar_f64_kernel,
+    pack_vector_f32_kernel,
     pack_vector_f64_kernel,
+    unpack_scalar_f32_kernel,
     unpack_scalar_f64_kernel,
+    unpack_vector_f32_kernel,
     unpack_vector_f64_kernel,
 )
 from .quantity import Quantity, QuantityHaloSpec
 from .rotate import rotate_scalar_data, rotate_vector_data
 from .types import NumpyModule
-from .utils import device_synchronize
+from .utils import device_synchronize, pfloat
 
 
 # ------------------------------------------------------------------------
@@ -708,16 +712,27 @@ class HaloDataTransformerGPU(HaloDataTransformer):
 
             # Use private stream
             with self._get_stream(cu_kernel_args.stream):
-                if quantity.metadata.dtype != np.float64:
-                    raise RuntimeError(f"Kernel requires f64 given {np.float64}")
-
                 # Launch kernel
                 blocks = 128
                 grid_x = (info_x.pack_buffer_size // blocks) + 1
-                if pack_scalar_f64_kernel is None:
+                # Pick a kernel looking at the precision set
+                pack_kernel = None
+                if pfloat() == np.float32:
+                    pack_kernel = pack_scalar_f32_kernel
+                elif pfloat() == np.float64 or pfloat() == float:
+                    pack_kernel = pack_scalar_f64_kernel
+                else:
+                    RuntimeError(
+                        f"Halo exchange pack kernel for precision {pfloat()} "
+                        "isn't implemented."
+                    )
+
+                # Check compile hasn't failed silently if this is the first
+                # call to the kernel
+                if pack_kernel is None:
                     RuntimeError("CUDA nvrtc failed")
                 else:
-                    pack_scalar_f64_kernel(
+                    pack_kernel(
                         (grid_x,),
                         (blocks,),
                         (
@@ -760,20 +775,30 @@ class HaloDataTransformerGPU(HaloDataTransformer):
 
             # Use private stream
             with self._get_stream(cu_kernel_args.stream):
-
                 # Buffer sizes
                 transformer_size = info_x.pack_buffer_size + info_y.pack_buffer_size
-
-                if quantity_x.metadata.dtype != np.float64:
-                    raise RuntimeError(f"Kernel requires f64 given {np.float64}")
 
                 # Launch kernel
                 blocks = 128
                 grid_x = (transformer_size // blocks) + 1
-                if pack_vector_f64_kernel is None:
+                # Pick a kernel looking at the precision set
+                pack_kernel = None
+                if pfloat() == np.float32:
+                    pack_kernel = pack_vector_f32_kernel
+                elif pfloat() == np.float64 or pfloat() == float:
+                    pack_kernel = pack_vector_f64_kernel
+                else:
+                    RuntimeError(
+                        f"Halo exchange pack kernel for precision {pfloat()} "
+                        "isn't implemented."
+                    )
+
+                # Check compile hasn't failed silently if this is the first
+                # call to the kernel
+                if pack_kernel is None:
                     RuntimeError("CUDA nvrtc failed")
                 else:
-                    pack_vector_f64_kernel(
+                    pack_kernel(
                         (grid_x,),
                         (blocks,),
                         (
@@ -836,10 +861,24 @@ class HaloDataTransformerGPU(HaloDataTransformer):
                 # Launch kernel
                 blocks = 128
                 grid_x = (info_x._unpack_buffer_size // blocks) + 1
-                if unpack_scalar_f64_kernel is None:
+                # Pick a kernel looking at the precision set
+                unpack_kernel = None
+                if pfloat() == np.float32:
+                    unpack_kernel = unpack_scalar_f32_kernel
+                elif pfloat() == np.float64 or pfloat() == float:
+                    unpack_kernel = unpack_scalar_f64_kernel
+                else:
+                    RuntimeError(
+                        f"Halo exchange pack kernel for precision {pfloat()} "
+                        "isn't implemented."
+                    )
+
+                # Check compile hasn't failed silently if this is the first
+                # call to the kernel
+                if unpack_kernel is None:
                     RuntimeError("CUDA nvrtc failed")
                 else:
-                    unpack_scalar_f64_kernel(
+                    unpack_kernel(
                         (grid_x,),
                         (blocks,),
                         (
@@ -878,10 +917,6 @@ class HaloDataTransformerGPU(HaloDataTransformer):
             info_x,
             info_y,
         ) in zip(quantities_x, quantities_y, self._infos_x, self._infos_y):
-            # We only have writte a f64 kernel
-            if quantity_x.metadata.dtype != np.float64:
-                raise RuntimeError(f"Kernel requires f64 given {np.float64}")
-
             cu_kernel_args = self._cu_kernel_args[info_x._id]
 
             # Use private stream
@@ -893,10 +928,24 @@ class HaloDataTransformerGPU(HaloDataTransformer):
                 # Launch kernel
                 blocks = 128
                 grid_x = (edge_size // blocks) + 1
-                if unpack_vector_f64_kernel is None:
+                # Pick a kernel looking at the precision set
+                unpack_kernel = None
+                if pfloat() == np.float32:
+                    unpack_kernel = unpack_vector_f32_kernel
+                elif pfloat() == np.float64 or pfloat() == float:
+                    unpack_kernel = unpack_vector_f64_kernel
+                else:
+                    RuntimeError(
+                        f"Halo exchange pack kernel for precision {pfloat()} "
+                        "isn't implemented."
+                    )
+
+                # Check compile hasn't failed silently if this is the first
+                # call to the kernel
+                if unpack_kernel is None:
                     RuntimeError("CUDA nvrtc failed")
                 else:
-                    unpack_vector_f64_kernel(
+                    unpack_kernel(
                         (grid_x,),
                         (blocks,),
                         (

--- a/util/pace/util/initialization/allocator.py
+++ b/util/pace/util/initialization/allocator.py
@@ -60,31 +60,41 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         units: str,
-        dtype: type = float,
+        dtype: type = np.float64,
+        allow_mismatch_float_precision: bool = False,
     ):
-        return self._allocate(self._numpy.empty, dims, units, dtype)
+        return self._allocate(
+            self._numpy.empty, dims, units, dtype, allow_mismatch_float_precision
+        )
 
     def zeros(
         self,
         dims: Sequence[str],
         units: str,
-        dtype: type = float,
+        dtype: type = np.float64,
+        allow_mismatch_float_precision: bool = False,
     ):
-        return self._allocate(self._numpy.zeros, dims, units, dtype)
+        return self._allocate(
+            self._numpy.zeros, dims, units, dtype, allow_mismatch_float_precision
+        )
 
     def ones(
         self,
         dims: Sequence[str],
         units: str,
-        dtype: type = float,
+        dtype: type = np.float64,
+        allow_mismatch_float_precision: bool = False,
     ):
-        return self._allocate(self._numpy.ones, dims, units, dtype)
+        return self._allocate(
+            self._numpy.ones, dims, units, dtype, allow_mismatch_float_precision
+        )
 
     def from_array(
         self,
         data: np.ndarray,
         dims: Sequence[str],
         units: str,
+        allow_mismatch_float_precision: bool = False,
     ):
         """
         Create a Quantity from a numpy array.
@@ -92,7 +102,12 @@ class QuantityFactory:
         That numpy array must correspond to the correct shape and extent
         for the given dims.
         """
-        base = self.empty(dims=dims, units=units, dtype=data.dtype)
+        base = self.empty(
+            dims=dims,
+            units=units,
+            dtype=data.dtype,
+            allow_mismatch_float_precision=allow_mismatch_float_precision,
+        )
         base.data[:] = base.np.asarray(data)
         return base
 
@@ -101,7 +116,8 @@ class QuantityFactory:
         allocator: Callable,
         dims: Sequence[str],
         units: str,
-        dtype: type = float,
+        dtype: type = np.float64,
+        allow_mismatch_float_precision: bool = False,
     ):
         origin = self.sizer.get_origin(dims)
         extent = self.sizer.get_extent(dims)
@@ -127,10 +143,14 @@ class QuantityFactory:
             origin=origin,
             extent=extent,
             gt4py_backend=self._backend(),
+            allow_mismatch_float_precision=allow_mismatch_float_precision,
         )
 
     def get_quantity_halo_spec(
-        self, dims: Sequence[str], n_halo: Optional[int] = None, dtype: type = float
+        self,
+        dims: Sequence[str],
+        n_halo: Optional[int] = None,
+        dtype: type = np.float64,
     ) -> QuantityHaloSpec:
         """Build memory specifications for the halo update.
 

--- a/util/pace/util/logging.py
+++ b/util/pace/util/logging.py
@@ -1,0 +1,25 @@
+import logging
+import sys
+
+from mpi4py import MPI
+
+
+def _pace_logger():
+    name_log = logging.getLogger(__name__)
+    name_log.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+        fmt=(
+            f"%(asctime)s|%(levelname)s|rank {MPI.COMM_WORLD.Get_rank()}|"
+            "%(name)s:%(message)s"
+        ),
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    name_log.addHandler(handler)
+    return name_log
+
+
+pace_log = _pace_logger()

--- a/util/pace/util/monitor/netcdf_monitor.py
+++ b/util/pace/util/monitor/netcdf_monitor.py
@@ -37,6 +37,7 @@ class _TimeChunkedVariable:
             data=self._data[: self._i_time, ...],
             dims=("time",) + tuple(self._dims),
             units=self._units,
+            allow_mismatch_float_precision=True,
         )
 
 

--- a/util/pace/util/monitor/netcdf_monitor.py
+++ b/util/pace/util/monitor/netcdf_monitor.py
@@ -28,11 +28,15 @@ class _TimeChunkedVariable:
         self._i_time = 1
 
     def append(self, quantity: Quantity):
-        self._data[self._i_time, ...] = to_numpy(quantity.transpose(self._dims).view[:])
+        # Allow mismatch precision here since this is I/O
+        self._data[self._i_time, ...] = to_numpy(
+            quantity.transpose(self._dims, allow_mismatch_float_precision=True).view[:]
+        )
         self._i_time += 1
 
     @property
     def data(self) -> Quantity:
+        # Allow mismatch precision here since this is I/O
         return Quantity(
             data=self._data[: self._i_time, ...],
             dims=("time",) + tuple(self._dims),

--- a/util/pace/util/quantity.py
+++ b/util/pace/util/quantity.py
@@ -4,8 +4,6 @@ from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 
-from pace.dsl.typing import Float
-
 from . import _xarray, constants
 from ._boundary_utils import bound_default_slice, shift_boundary_slice_tuple
 from ._optional_imports import cupy, dace, gt4py
@@ -297,6 +295,11 @@ class Quantity:
                 storage attribute is disabled and will raise an exception. Will raise
                 a TypeError if this is given with a gt4py storage type as data
         """
+        # This include so deep in pace.util can lead to circular include
+        # Since Quantity builds should not be in the critical path, this
+        # is "fine" to do here
+        from pace.dsl.typing import Float
+
         if (
             not allow_mismatch_float_precision
             and _is_float(data.dtype)
@@ -533,7 +536,11 @@ class Quantity:
                 "DaCe module is not available."
             )
 
-    def transpose(self, target_dims: Sequence[Union[str, Iterable[str]]]) -> "Quantity":
+    def transpose(
+        self,
+        target_dims: Sequence[Union[str, Iterable[str]]],
+        allow_mismatch_float_precision: bool = False,
+    ) -> "Quantity":
         """Change the dimension order of this Quantity.
 
         Args:
@@ -582,6 +589,7 @@ class Quantity:
             origin=transpose_sequence(self.origin, transpose_order),
             extent=transpose_sequence(self.extent, transpose_order),
             gt4py_backend=self.gt4py_backend,
+            allow_mismatch_float_precision=allow_mismatch_float_precision,
         )
         transposed._attrs = self._attrs
         return transposed

--- a/util/pace/util/quantity.py
+++ b/util/pace/util/quantity.py
@@ -4,11 +4,12 @@ from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 
+from pace.dsl.typing import Float
+
 from . import _xarray, constants
 from ._boundary_utils import bound_default_slice, shift_boundary_slice_tuple
 from ._optional_imports import cupy, dace, gt4py
 from .types import NumpyModule
-from .utils import pfloat
 
 
 if cupy is None:
@@ -299,11 +300,11 @@ class Quantity:
         if (
             not allow_mismatch_float_precision
             and _is_float(data.dtype)
-            and data.dtype != pfloat()
+            and data.dtype != Float
         ):
             raise ValueError(
                 f"Floating-point data type mismatch, asked for {data.dtype}, "
-                f"Pace configured for {pfloat()}"
+                f"Pace configured for {Float}"
             )
         if origin is None:
             origin = (0,) * len(dims)  # default origin at origin of array

--- a/util/pace/util/quantity.py
+++ b/util/pace/util/quantity.py
@@ -295,9 +295,26 @@ class Quantity:
                 storage attribute is disabled and will raise an exception. Will raise
                 a TypeError if this is given with a gt4py storage type as data
         """
-        # This include so deep in pace.util can lead to circular include
+        # [Florian 01/23] This include so deep in pace.util can lead to circular include
         # Since Quantity builds should not be in the critical path, this
-        # is "fine" to do here
+        # is "fine" to do here.
+        # Strategies that seems obvious (but aren't)
+        #  - move Float in a seperate file, e.g. pace.dsl.typing_float
+        #    Problem: circular dependency is on the import of anything
+        #    under pace.dsl here
+        #  - Remove boundary import (the culprit of circular)
+        #    Problem: it's a legit need of Communicator which is also a legit need
+        #    upstream
+        #  - Make the Float a parameter to the __init__ of Quantity
+        #    Probably the _actual_ way to fix this, lots of changes might have
+        #    heavy side-effect and be bug prone.
+        #    Therefore will require a seperate full review
+        # Apologies to whoever founds this. If it's future me... I deserved it.
+        #
+        # With deep regrets,
+        # Past Florian.
+        #
+        # ToDo: fix it
         from pace.dsl.typing import Float
 
         if (

--- a/util/pace/util/quantity.py
+++ b/util/pace/util/quantity.py
@@ -295,26 +295,8 @@ class Quantity:
                 storage attribute is disabled and will raise an exception. Will raise
                 a TypeError if this is given with a gt4py storage type as data
         """
-        # [Florian 01/23] This include so deep in pace.util can lead to circular include
-        # Since Quantity builds should not be in the critical path, this
-        # is "fine" to do here.
-        # Strategies that seems obvious (but aren't)
-        #  - move Float in a seperate file, e.g. pace.dsl.typing_float
-        #    Problem: circular dependency is on the import of anything
-        #    under pace.dsl here
-        #  - Remove boundary import (the culprit of circular)
-        #    Problem: it's a legit need of Communicator which is also a legit need
-        #    upstream
-        #  - Make the Float a parameter to the __init__ of Quantity
-        #    Probably the _actual_ way to fix this, lots of changes might have
-        #    heavy side-effect and be bug prone.
-        #    Therefore will require a seperate full review
-        # Apologies to whoever founds this. If it's future me... I deserved it.
-        #
-        # With deep regrets,
-        # Past Florian.
-        #
-        # ToDo: fix it
+        # ToDo: [Florian 01/23] Kill the abomination.
+        # See https://github.com/NOAA-GFDL/pace/issues/3
         from pace.dsl.typing import Float
 
         if (

--- a/util/pace/util/utils.py
+++ b/util/pace/util/utils.py
@@ -21,11 +21,6 @@ else:
 T = TypeVar("T")
 
 
-def pfloat():
-    """Parametric float to switch precision mode real numbers."""
-    return np.float64
-
-
 def list_by_dims(
     dims: Sequence[str], horizontal_list: Sequence[T], non_horizontal_value: T
 ) -> Tuple[T, ...]:

--- a/util/pace/util/utils.py
+++ b/util/pace/util/utils.py
@@ -18,8 +18,12 @@ if cp is not None:
 else:
     GPU_AVAILABLE = False
 
-
 T = TypeVar("T")
+
+
+def pfloat():
+    """Parametric float to switch precision mode real numbers."""
+    return np.float64
 
 
 def list_by_dims(

--- a/util/tests/test_halo_data_transformer.py
+++ b/util/tests/test_halo_data_transformer.py
@@ -427,7 +427,9 @@ def test_data_transformer_vector_pack_unpack(quantity, rotation, n_halos):
     ]
 
     data_transformer = HaloDataTransformer.get(
-        x_quantity.np, exchange_descriptors_x, exchange_descriptors_y
+        x_quantity.np,
+        exchange_descriptors_x,
+        exchange_descriptors_y,
     )
 
     data_transformer.async_pack([x_quantity, x_quantity], [y_quantity, y_quantity])


### PR DESCRIPTION
## Purpose

Main feature is enable 32-bit float, but this also covers hotfix & quality of life improvements to orchestration
* 32-bit float throughout (**GT4Py MERGE PENDING**)
* hotfix for orchestration for GT4Py v1
* using pace logger to punch through stdout in hybrid use
* optimizing re-entry call to orchestration for hybrid use
* QoL: BuildAndRun will truly build, then use the most efficient path to Run all subsequent runs
* QoL: build on checks is optional for now due to tuple != tuple weird bug

## Code changes:

- PACE_FLOAT_PRECISION env var controls the precision of the float program wide. Defaults to 64 for backward compatibility.
- Introduce FrozenCSDFG which froze argument manipulation when using orchestration. Caveat: if any reallocation occurs, the system will crash in non trivial ways
- Build / Run function path in Orchestration have been clean up and used a FrozenCSDFG interface for calss

## Requirements changes:

- GTPy update (PENDING)

## Infrastructure changes:

No CI infra available, tested on local box.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated

