### PR TITLE
Feature/dp driver

### DIFF
--- a/driver/examples/configs/baroclinic_c12_dp.yaml
+++ b/driver/examples/configs/baroclinic_c12_dp.yaml
@@ -12,7 +12,6 @@ grid_config:
     dx_const: 3000.0
     dy_const: 3000.0
     deglat: 10.0
-    u_max: 355.0
 initialization:
   type: baroclinic
 performance_config:
@@ -95,6 +94,7 @@ dycore_config:
   tau_v2l: 90.
   fv_sg_adj: 0
   n_sponge: 48
+  u_max: 355.0
 
 physics_config:
   hydrostatic: false

--- a/driver/examples/configs/baroclinic_c12_dp.yaml
+++ b/driver/examples/configs/baroclinic_c12_dp.yaml
@@ -1,0 +1,102 @@
+stencil_config:
+  compilation_config:
+    backend: numpy
+    rebuild: false
+    validate_args: true
+    format_source: false
+    device_sync: false
+grid_config:
+  type: generated
+  config:
+    grid_type: 4
+    dx_const: 3000.0
+    dy_const: 3000.0
+    deglat: 10.0
+    u_max: 355.0
+initialization:
+  type: baroclinic
+performance_config:
+  collect_performance: true
+  experiment_name: c12_baroclinic
+nx_tile: 12
+nz: 79
+dt_atmos: 225
+minutes: 15
+layout:
+  - 1
+  - 1
+diagnostics_config:
+  path: output
+  output_format: netcdf
+  names:
+    - u
+    - v
+    - ua
+    - va
+    - pt
+    - delp
+    - qvapor
+    - qliquid
+    - qice
+    - qrain
+    - qsnow
+    - qgraupel
+  z_select:
+    - level: 65
+      names:
+        - pt
+dycore_config:
+  a_imp: 1.0
+  beta: 0.
+  consv_te: 0.
+  d2_bg: 0.
+  d2_bg_k1: 0.2
+  d2_bg_k2: 0.1
+  d4_bg: 0.15
+  d_con: 1.0
+  d_ext: 0.0
+  dddmp: 0.5
+  delt_max: 0.002
+  do_sat_adj: true
+  do_vort_damp: true
+  fill: true
+  hord_dp: 6
+  hord_mt: 6
+  hord_tm: 6
+  hord_tr: 8
+  hord_vt: 6
+  hydrostatic: false
+  k_split: 1
+  ke_bg: 0.
+  kord_mt: 9
+  kord_tm: -9
+  kord_tr: 9
+  kord_wz: 9
+  n_split: 1
+  nord: 3
+  nwat: 6
+  p_fac: 0.05
+  rf_cutoff: 3000.
+  rf_fast: true
+  tau: 10.
+  vtdm4: 0.06
+  z_tracer: true
+  do_qa: true
+  tau_i2s: 1000.
+  tau_g2v: 1200.
+  ql_gen: 0.001
+  ql_mlt: 0.002
+  qs_mlt: 0.000001
+  qi_lim: 1.0
+  dw_ocean: 0.1
+  dw_land: 0.15
+  icloud_f: 0
+  tau_l2v: 300.
+  tau_v2l: 90.
+  fv_sg_adj: 0
+  n_sponge: 48
+
+physics_config:
+  hydrostatic: false
+  nwat: 6
+  do_qa: true

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -273,6 +273,9 @@ class DriverConfig:
             kwargs["grid_config"] = GridInitializerSelector.from_dict(
                 kwargs["grid_config"]
             )
+            grid_type = kwargs["grid_config"].config.grid_type
+            if grid_type != 0:
+                kwargs["dycore_config"].grid_type = grid_type
 
         if (
             isinstance(kwargs["stencil_config"], dict)

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -274,7 +274,8 @@ class DriverConfig:
                 kwargs["grid_config"]
             )
             grid_type = kwargs["grid_config"].config.grid_type
-            if grid_type != 0:
+            # Copy grid_type to the DycoreConfig if it's not the default value
+            if grid_type != 0: 
                 kwargs["dycore_config"].grid_type = grid_type
 
         if (

--- a/driver/pace/driver/grid.py
+++ b/driver/pace/driver/grid.py
@@ -85,12 +85,22 @@ class GeneratedGridConfig(GridInitializer):
         lon_target: desired center longitude for refined tile (deg)
         lat_target: desired center latitude for refined tile (deg)
         restart_path: if given, load vertical grid from restart file
+        grid_type: type of grid, 0 is a gnomonic cubed-sphere, 4 is doubly-periodic
+        dx_const: constant x-width of grid cells on a dp-grid
+        dy_const: constant y-width of grid cells on a dp-grid
+        deglat: latitude to use for coriolis calculations on a dp-grid
+        u_max: maximum wind speed for grid_type > 3
     """
 
     stretch_factor: Optional[float] = 1.0
     lon_target: Optional[float] = 350.0
     lat_target: Optional[float] = -90.0
     restart_path: Optional[str] = None
+    grid_type: Optional[int] = 0
+    dx_const: Optional[float] = 1000.0
+    dy_const: Optional[float] = 1000.0
+    deglat: Optional[float] = 15.0
+    u_max: Optional[float] = 350.0
 
     def get_grid(
         self,
@@ -99,7 +109,12 @@ class GeneratedGridConfig(GridInitializer):
     ) -> Tuple[DampingCoefficients, DriverGridData, GridData]:
 
         metric_terms = MetricTerms(
-            quantity_factory=quantity_factory, communicator=communicator
+            quantity_factory=quantity_factory,
+            communicator=communicator,
+            grid_type=self.grid_type,
+            dx_const=self.dx_const,
+            dy_const=self.dy_const,
+            deglat=self.deglat,
         )
         if self.stretch_factor != 1:  # do horizontal grid transformation
             _transform_horizontal_grid(

--- a/driver/pace/driver/grid.py
+++ b/driver/pace/driver/grid.py
@@ -89,7 +89,6 @@ class GeneratedGridConfig(GridInitializer):
         dx_const: constant x-width of grid cells on a dp-grid
         dy_const: constant y-width of grid cells on a dp-grid
         deglat: latitude to use for coriolis calculations on a dp-grid
-        u_max: maximum wind speed for grid_type > 3
     """
 
     stretch_factor: Optional[float] = 1.0
@@ -100,7 +99,6 @@ class GeneratedGridConfig(GridInitializer):
     dx_const: Optional[float] = 1000.0
     dy_const: Optional[float] = 1000.0
     deglat: Optional[float] = 15.0
-    u_max: Optional[float] = 350.0
 
     def get_grid(
         self,

--- a/fv3core/pace/fv3core/_config.py
+++ b/fv3core/pace/fv3core/_config.py
@@ -195,6 +195,7 @@ class DynamicalCoreConfig:
     do_qa: bool = DEFAULT_BOOL
     layout: Tuple[int, int] = NamelistDefaults.layout
     grid_type: int = NamelistDefaults.grid_type
+    u_max: float = NamelistDefaults.u_max  # max windspeed for dp config
     do_f3d: bool = NamelistDefaults.do_f3d
     inline_q: bool = NamelistDefaults.inline_q
     do_skeb: bool = NamelistDefaults.do_skeb  # save dissipation estimate
@@ -334,6 +335,7 @@ class DynamicalCoreConfig:
             do_qa=namelist.do_qa,
             layout=namelist.layout,
             grid_type=namelist.grid_type,
+            u_max=namelist.u_max,
             do_f3d=namelist.do_f3d,
             inline_q=namelist.inline_q,
             do_skeb=namelist.do_skeb,

--- a/tests/main/driver/test_example_configs.py
+++ b/tests/main/driver/test_example_configs.py
@@ -13,6 +13,7 @@ EXAMPLE_CONFIGS_DIR = os.path.join(dirname, "../../../driver/examples/configs/")
 
 TESTED_CONFIGS: List[str] = [
     "baroclinic_c12.yaml",
+    "baroclinic_c12_dp.yaml",
     "baroclinic_c12_comm_read.yaml",
     "baroclinic_c12_comm_write.yaml",
     "baroclinic_c12_null_comm.yaml",

--- a/util/HISTORY.md
+++ b/util/HISTORY.md
@@ -4,6 +4,8 @@ History
 latest
 ------
 
+- Added `dx_const`, `dy_const`, `deglat`, and `u_max` namelist settings for doubly-periodic grids
+- Added `dx_const`, `dy_const`, and `deglat` to grid generation code for doubly-periodic grids
 - Added f32 support to halo exchange data transformation
 
 v0.10.0

--- a/util/pace/util/grid/generation.py
+++ b/util/pace/util/grid/generation.py
@@ -222,8 +222,11 @@ class MetricTerms:
         quantity_factory: util.QuantityFactory,
         communicator: util.CubedSphereCommunicator,
         grid_type: int = 0,
+        dx_const: float = 1000.0,
+        dy_const: float = 1000.0,
+        deglat: float = 15.0,
     ):
-        assert grid_type < 3
+        # assert grid_type < 3
         self._grid_type = grid_type
         self._halo = N_HALO_DEFAULT
         self._comm = communicator
@@ -375,6 +378,9 @@ class MetricTerms:
         communicator: util.CubedSphereCommunicator,
         backend: str,
         grid_type: int = 0,
+        dx_const: float = 1000.0,
+        dy_const: float = 1000.0,
+        deglat: float = 15.0,
     ) -> "MetricTerms":
         sizer = util.SubtileGridSizer.from_tile_params(
             nx_tile=npx - 1,
@@ -393,6 +399,9 @@ class MetricTerms:
             quantity_factory=quantity_factory,
             communicator=communicator,
             grid_type=grid_type,
+            dx_const=dx_const,
+            dy_const=dy_const,
+            deglat=deglat,
         )
 
     @property

--- a/util/pace/util/grid/generation.py
+++ b/util/pace/util/grid/generation.py
@@ -226,7 +226,7 @@ class MetricTerms:
         dy_const: float = 1000.0,
         deglat: float = 15.0,
     ):
-        # assert grid_type < 3
+        assert grid_type < 3
         self._grid_type = grid_type
         self._halo = N_HALO_DEFAULT
         self._comm = communicator

--- a/util/pace/util/namelist.py
+++ b/util/pace/util/namelist.py
@@ -12,6 +12,10 @@ DEFAULT_BOOL = False
 class NamelistDefaults:
     layout = (1, 1)
     grid_type = 0
+    dx_const = 1000.0
+    dy_const = 1000.0
+    deglat = 15.0
+    u_max = 350.0
     do_f3d = False
     inline_q = False
     do_skeb = False  # save dissipation estimate
@@ -372,6 +376,10 @@ class Namelist:
     # fvmxl: Any
     # ldebug: Any
     grid_type: int = NamelistDefaults.grid_type
+    dx_const: float = NamelistDefaults.dx_const
+    dy_const: float = NamelistDefaults.dy_const
+    deglat: float = NamelistDefaults.deglat
+    u_max: float = NamelistDefaults.u_max
     do_f3d: bool = NamelistDefaults.do_f3d
     inline_q: bool = NamelistDefaults.inline_q
     do_skeb: bool = NamelistDefaults.do_skeb  # save dissipation estimate


### PR DESCRIPTION
## Purpose

This PR adds the ability for the Pace driver to handle doubly-periodic domains. The grid_type setting is specified in the grid config section and is copied to the dycore config (as opposed to Fortran, which specifies grid_config in the dycore config)

## Code changes:

- `driver/examples/configs/baroclinic_c12_dp.yaml`: Added to test the doubly-periodic configuration handling
- `driver/pace/driver/driver.py`: grid_type copied from grid_config to dycore_config if nonzero
- `driver/pace/driver/grid.py`: Added grid_type, dx_const, dy_const, and deglat to the GeneratedGridConfig class, pass them to MetricTerms generation
- `fv3core/pace/fv3core/_config.py`: added u_max to dycore config
- `tests/main/driver/test_example_configs.py`: Added baroclinic_c12_dp config to tests
- `util/pace/util/grid/generation.py`: Added grid_type, dx_const, dy_const, and deglat as input args for doubly-periodic grid generation
- `util/pace/util/namelist.py`: Added dx_const, dy_const, deglat, and u_max as namelist settings for doubly periodic runs
- `util/HISTORY.md`: Updated with latest additions to the utils

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
