### PR TITLE
Resolving Issue #22: Changed instances of 'FV3DYCORE' to 'GFDL' in util/pace/util/constants.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ After the run completes, you will see an output direcotry `output.zarr`. An exam
 ### Environment variable configuration
 
 - `PACE_CONSTANTS`: Pace is bundled with various constants (see _util/pace/util/constants.py_).
-  - `FV3DYCORE` NOAA's FV3 dynamical core constants (original port)
+  - `GFDL` NOAA's FV3 dynamical core constants (original port)
   - `GFS` Constant as defined in NOAA GFS
   - `GEOS`  Constant as defined in GEOS v13
 - `PACE_FLOAT_PRECISION`: default precision of the field & scalars in the numerics. Default to 64.

--- a/util/pace/util/constants.py
+++ b/util/pace/util/constants.py
@@ -8,7 +8,7 @@ from pace.util.logging import pace_log
 # package and the other used for the Dycore. Their difference are small but significant
 # In addition the GSFC's GEOS model as its own variables
 class ConstantVersions(Enum):
-    FV3DYCORE = "FV3DYCORE"  # NOAA's FV3 dynamical core constants (original port)
+    GFDL = "GFDL"  # NOAA's FV3 dynamical core constants (original port)
     GFS = "GFS"  # Constant as defined in NOAA GFS
     GEOS = "GEOS"  # Constant as defined in GEOS v13
 
@@ -66,9 +66,7 @@ N_HALO_DEFAULT = 3
 if CONST_VERSION == ConstantVersions.GEOS:
     # 'qlcd' is exchanged in GEOS
     NQ = 9
-elif (
-    CONST_VERSION == ConstantVersions.GFS or CONST_VERSION == ConstantVersions.FV3DYCORE
-):
+elif CONST_VERSION == ConstantVersions.GFS or CONST_VERSION == ConstantVersions.GFDL:
     NQ = 8
 else:
     raise RuntimeError("Constant selector failed, bad code.")
@@ -104,7 +102,7 @@ elif CONST_VERSION == ConstantVersions.GFS:
     KAPPA = RDGAS / CP_AIR  # Specific heat capacity of dry air at
     TFREEZE = 273.15
     SAT_ADJUST_THRESHOLD = 1.0e-8
-elif CONST_VERSION == ConstantVersions.FV3DYCORE:
+elif CONST_VERSION == ConstantVersions.GFDL:
     RADIUS = 6371.0e3  # Radius of the Earth [m] #6371.0e3
     PI = 3.14159265358979323846  # 3.14159265358979323846
     OMEGA = 7.292e-5  # Rotation of the earth  # 7.292e-5


### PR DESCRIPTION

## Purpose

This pull request resolves Issue #22. Instances of 'FV3DYCORE' constants have been re-labeled 'GFDL'

## Code changes:

- README.md refers now to the constants as 'GFDL
- util/pace/util/constants.py refers to 'FV3DYCORE' constants as 'GFDL' constants

## Requirements changes:

- N/A

## Infrastructure changes:

- N/A

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [x] The names of all the new contributors have been added to CONTRIBUTORS.md
