### PR TITLE
Move Active Physics Schemes to Config

### DIFF
--- a/docs/physics/state.rst
+++ b/docs/physics/state.rst
@@ -38,6 +38,6 @@ You can initialize a zero-filled PhysicsState and MicrophysicsState from other P
 
     >>> quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend="numpy")
     >>> physics_state = PhysicsState.init_zeros(
-    ...  quantity_factory=quantity_factory, active_packages=["microphysics"]
+    ...  quantity_factory=quantity_factory, schemes=["microphysics"]
     ... )
     >>> microphysics_state = physics_state.microphysics

--- a/docs/physics/state.rst
+++ b/docs/physics/state.rst
@@ -38,6 +38,6 @@ You can initialize a zero-filled PhysicsState and MicrophysicsState from other P
 
     >>> quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend="numpy")
     >>> physics_state = PhysicsState.init_zeros(
-    ...  quantity_factory=quantity_factory, schemes=["microphysics"]
+    ...  quantity_factory=quantity_factory, schemes=["GFS_microphysics"]
     ... )
     >>> microphysics_state = physics_state.microphysics

--- a/driver/examples/configs/baroclinic_c12_explicit_physics.yaml
+++ b/driver/examples/configs/baroclinic_c12_explicit_physics.yaml
@@ -1,0 +1,98 @@
+stencil_config:
+  compilation_config:
+    backend: numpy
+    rebuild: false
+    validate_args: true
+    format_source: false
+    device_sync: false
+initialization:
+  type: analytic
+  config:
+    case: baroclinic
+performance_config:
+  collect_performance: true
+  experiment_name: c12_baroclinic
+nx_tile: 12
+nz: 79
+dt_atmos: 225
+minutes: 15
+layout:
+  - 1
+  - 1
+diagnostics_config:
+  path: output
+  output_format: netcdf
+  names:
+    - u
+    - v
+    - ua
+    - va
+    - pt
+    - delp
+    - qvapor
+    - qliquid
+    - qice
+    - qrain
+    - qsnow
+    - qgraupel
+  z_select:
+    - level: 65
+      names:
+        - pt
+dycore_config:
+  a_imp: 1.0
+  beta: 0.
+  consv_te: 0.
+  d2_bg: 0.
+  d2_bg_k1: 0.2
+  d2_bg_k2: 0.1
+  d4_bg: 0.15
+  d_con: 1.0
+  d_ext: 0.0
+  dddmp: 0.5
+  delt_max: 0.002
+  do_sat_adj: true
+  do_vort_damp: true
+  fill: true
+  hord_dp: 6
+  hord_mt: 6
+  hord_tm: 6
+  hord_tr: 8
+  hord_vt: 6
+  hydrostatic: false
+  k_split: 1
+  ke_bg: 0.
+  kord_mt: 9
+  kord_tm: -9
+  kord_tr: 9
+  kord_wz: 9
+  n_split: 1
+  nord: 3
+  nwat: 6
+  p_fac: 0.05
+  rf_cutoff: 3000.
+  rf_fast: true
+  tau: 10.
+  vtdm4: 0.06
+  z_tracer: true
+  do_qa: true
+  tau_i2s: 1000.
+  tau_g2v: 1200.
+  ql_gen: 0.001
+  ql_mlt: 0.002
+  qs_mlt: 0.000001
+  qi_lim: 1.0
+  dw_ocean: 0.1
+  dw_land: 0.15
+  icloud_f: 0
+  tau_l2v: 300.
+  tau_v2l: 90.
+  fv_sg_adj: 0
+  n_sponge: 48
+
+physics_config:
+  hydrostatic: false
+  nwat: 6
+  do_qa: true
+  schemes:
+    - GFS_microphysics

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -231,6 +231,7 @@ class DriverConfig:
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
+            schemes=self.physics_config.schemes
         )
 
     @classmethod
@@ -508,7 +509,6 @@ class Driver:
                     quantity_factory=self.quantity_factory,
                     grid_data=self.state.grid_data,
                     namelist=self.config.physics_config,
-                    active_packages=["microphysics"],
                 )
             else:
                 # Make sure those are set to None to raise any issues

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -231,7 +231,7 @@ class DriverConfig:
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
-            schemes=self.physics_config.schemes
+            schemes=self.physics_config.schemes,
         )
 
     @classmethod

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -328,6 +328,9 @@ class DriverConfig:
         config_dict["initialization"]["type"] = "restart"
         config_dict["initialization"]["config"]["start_time"] = time
         config_dict["initialization"]["config"]["path"] = restart_path
+        # convert physics package enum to str
+        schemes = [scheme.value for scheme in config_dict["physics_config"]["schemes"]]
+        config_dict["physics_config"]["schemes"] = schemes
         # restart config doesn't have 'case'
         if "case" in config_dict["initialization"]["config"].keys():
             del config_dict["initialization"]["config"]["case"]

--- a/driver/pace/driver/initialization.py
+++ b/driver/pace/driver/initialization.py
@@ -3,7 +3,7 @@ import dataclasses
 import os
 import pathlib
 from datetime import datetime
-from typing import Callable, ClassVar, Type, TypeVar
+from typing import Callable, ClassVar, List, Type, TypeVar
 
 import f90nml
 
@@ -40,7 +40,7 @@ class Initializer(abc.ABC):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: list[str],
+        schemes: List[str],
     ) -> DriverState:
         ...
 
@@ -78,7 +78,7 @@ class InitializerSelector(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: list[str],
+        schemes: List[str],
     ) -> DriverState:
         return self.config.get_driver_state(
             quantity_factory=quantity_factory,
@@ -112,7 +112,7 @@ class AnalyticInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: list[str],
+        schemes: List[str],
     ) -> DriverState:
         dycore_state = analytic_init.init_analytic_state(
             analytic_init_case=self.case,
@@ -156,7 +156,7 @@ class RestartInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: list[str],
+        schemes: List[str],
     ) -> DriverState:
         state = _restart_driver_state(
             self.path,
@@ -207,7 +207,7 @@ class FortranRestartInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: list[str],
+        schemes: List[str],
     ) -> DriverState:
         state = _restart_driver_state(
             self.path,
@@ -280,7 +280,7 @@ class SerialboxInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: list[str],
+        schemes: List[str],
     ) -> DriverState:
         backend = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM], units="unknown"
@@ -358,7 +358,7 @@ class PredefinedStateInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: list[str],
+        schemes: List[str],
     ) -> DriverState:
         return DriverState(
             dycore_state=self.dycore_state,

--- a/driver/pace/driver/initialization.py
+++ b/driver/pace/driver/initialization.py
@@ -40,6 +40,7 @@ class Initializer(abc.ABC):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
+        schemes: list[str],
     ) -> DriverState:
         ...
 
@@ -77,6 +78,7 @@ class InitializerSelector(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
+        schemes: list[str],
     ) -> DriverState:
         return self.config.get_driver_state(
             quantity_factory=quantity_factory,
@@ -84,6 +86,7 @@ class InitializerSelector(Initializer):
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
+            schemes=schemes
         )
 
     @classmethod
@@ -109,6 +112,7 @@ class AnalyticInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
+        schemes: list[str],
     ) -> DriverState:
         dycore_state = analytic_init.init_analytic_state(
             analytic_init_case=self.case,
@@ -120,7 +124,7 @@ class AnalyticInit(Initializer):
             comm=communicator,
         )
         physics_state = pace.physics.PhysicsState.init_zeros(
-            quantity_factory=quantity_factory, active_packages=["microphysics"]
+            quantity_factory=quantity_factory, schemes=schemes
         )
         tendency_state = TendencyState.init_zeros(
             quantity_factory=quantity_factory,
@@ -152,6 +156,7 @@ class RestartInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
+        schemes: list[str],
     ) -> DriverState:
         state = _restart_driver_state(
             self.path,
@@ -161,6 +166,7 @@ class RestartInit(Initializer):
             damping_coefficients,
             driver_grid_data,
             grid_data,
+            schemes,
         )
 
         return state
@@ -201,6 +207,7 @@ class FortranRestartInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
+        schemes: list[str],
     ) -> DriverState:
         state = _restart_driver_state(
             self.path,
@@ -210,6 +217,7 @@ class FortranRestartInit(Initializer):
             damping_coefficients,
             driver_grid_data,
             grid_data,
+            schemes,
         )
 
         _update_fortran_restart_pe_peln(state)
@@ -272,6 +280,7 @@ class SerialboxInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
+        schemes: list[str],
     ) -> DriverState:
         backend = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM], units="unknown"
@@ -280,7 +289,7 @@ class SerialboxInit(Initializer):
         dycore_state = self._initialize_dycore_state(communicator, backend)
         physics_state = pace.physics.PhysicsState.init_zeros(
             quantity_factory=quantity_factory,
-            active_packages=["microphysics"],
+            schemes=schemes,
         )
         tendency_state = TendencyState.init_zeros(quantity_factory=quantity_factory)
 

--- a/driver/pace/driver/initialization.py
+++ b/driver/pace/driver/initialization.py
@@ -40,7 +40,7 @@ class Initializer(abc.ABC):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: List[str],
+        schemes: List[pace.physics.PHYSICS_PACKAGES],
     ) -> DriverState:
         ...
 
@@ -78,7 +78,7 @@ class InitializerSelector(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: List[str],
+        schemes: List[pace.physics.PHYSICS_PACKAGES],
     ) -> DriverState:
         return self.config.get_driver_state(
             quantity_factory=quantity_factory,
@@ -112,7 +112,7 @@ class AnalyticInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: List[str],
+        schemes: List[pace.physics.PHYSICS_PACKAGES],
     ) -> DriverState:
         dycore_state = analytic_init.init_analytic_state(
             analytic_init_case=self.case,
@@ -156,7 +156,7 @@ class RestartInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: List[str],
+        schemes: List[pace.physics.PHYSICS_PACKAGES],
     ) -> DriverState:
         state = _restart_driver_state(
             self.path,
@@ -207,7 +207,7 @@ class FortranRestartInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: List[str],
+        schemes: List[pace.physics.PHYSICS_PACKAGES],
     ) -> DriverState:
         state = _restart_driver_state(
             self.path,
@@ -280,7 +280,7 @@ class SerialboxInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: List[str],
+        schemes: List[pace.physics.PHYSICS_PACKAGES],
     ) -> DriverState:
         backend = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM], units="unknown"
@@ -358,7 +358,7 @@ class PredefinedStateInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: List[str],
+        schemes: List[pace.physics.PHYSICS_PACKAGES],
     ) -> DriverState:
         return DriverState(
             dycore_state=self.dycore_state,

--- a/driver/pace/driver/initialization.py
+++ b/driver/pace/driver/initialization.py
@@ -86,7 +86,7 @@ class InitializerSelector(Initializer):
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
-            schemes=schemes
+            schemes=schemes,
         )
 
     @classmethod
@@ -358,6 +358,7 @@ class PredefinedStateInit(Initializer):
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
+        schemes: list[str],
     ) -> DriverState:
         return DriverState(
             dycore_state=self.dycore_state,

--- a/driver/pace/driver/state.py
+++ b/driver/pace/driver/state.py
@@ -76,7 +76,7 @@ class DriverState:
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: List[str],
+        schemes: List[pace.physics.PHYSICS_PACKAGES],
     ) -> "DriverState":
         comm = driver_config.comm_config.get_comm()
         communicator = pace.util.Communicator.from_layout(
@@ -179,7 +179,7 @@ def _restart_driver_state(
     damping_coefficients: pace.util.grid.DampingCoefficients,
     driver_grid_data: pace.util.grid.DriverGridData,
     grid_data: pace.util.grid.GridData,
-    schemes: List[str],
+    schemes: List[pace.physics.PHYSICS_PACKAGES],
 ):
     fs = pace.util.get_fs(path)
 

--- a/driver/pace/driver/state.py
+++ b/driver/pace/driver/state.py
@@ -1,5 +1,6 @@
 import dataclasses
 from dataclasses import fields
+from typing import List
 
 import xarray as xr
 
@@ -75,7 +76,7 @@ class DriverState:
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
-        schemes: list[str],
+        schemes: List[str],
     ) -> "DriverState":
         comm = driver_config.comm_config.get_comm()
         communicator = pace.util.Communicator.from_layout(
@@ -103,7 +104,7 @@ class DriverState:
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
-            schemes=schemes
+            schemes=schemes,
         )
         return state
 
@@ -178,7 +179,7 @@ def _restart_driver_state(
     damping_coefficients: pace.util.grid.DampingCoefficients,
     driver_grid_data: pace.util.grid.DriverGridData,
     grid_data: pace.util.grid.GridData,
-    schemes: list[str],
+    schemes: List[str],
 ):
     fs = pace.util.get_fs(path)
 

--- a/driver/pace/driver/state.py
+++ b/driver/pace/driver/state.py
@@ -75,6 +75,7 @@ class DriverState:
         damping_coefficients: pace.util.grid.DampingCoefficients,
         driver_grid_data: pace.util.grid.DriverGridData,
         grid_data: pace.util.grid.GridData,
+        schemes: list[str],
     ) -> "DriverState":
         comm = driver_config.comm_config.get_comm()
         communicator = pace.util.Communicator.from_layout(
@@ -102,6 +103,7 @@ class DriverState:
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
+            schemes=schemes
         )
         return state
 
@@ -176,6 +178,7 @@ def _restart_driver_state(
     damping_coefficients: pace.util.grid.DampingCoefficients,
     driver_grid_data: pace.util.grid.DriverGridData,
     grid_data: pace.util.grid.GridData,
+    schemes: list[str],
 ):
     fs = pace.util.get_fs(path)
 
@@ -197,12 +200,11 @@ def _restart_driver_state(
             "restart_dycore_state",
         )
 
-    active_packages = ["microphysics"]
     physics_state = pace.physics.PhysicsState.init_zeros(
-        quantity_factory=quantity_factory, active_packages=active_packages
+        quantity_factory=quantity_factory, schemes=schemes
     )
 
-    physics_state.__post_init__(quantity_factory, active_packages)
+    physics_state.__post_init__(quantity_factory, schemes)
     tendency_state = TendencyState.init_zeros(
         quantity_factory=quantity_factory,
     )

--- a/driver/tests/mpi/test_restart.py
+++ b/driver/tests/mpi/test_restart.py
@@ -11,6 +11,7 @@ import pace.dsl
 import pace.util
 from pace.driver import DriverConfig
 from pace.driver.state import DriverState
+from pace.physics import PHYSICS_PACKAGES
 
 
 # The packages we import will import MPI, causing an MPI init, but we don't actually
@@ -65,6 +66,7 @@ def test_restart():
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
+            schemes=[PHYSICS_PACKAGES["GFS_microphysics"]],
         )
 
         assert isinstance(driver_state, DriverState)

--- a/fv3core/pace/fv3core/initialization/analytic_init.py
+++ b/fv3core/pace/fv3core/initialization/analytic_init.py
@@ -1,13 +1,9 @@
-from enum import Enum, EnumMeta
+from enum import Enum
 
 import pace.util as fv3util
+from pace.util import MetaEnumStr
 from pace.fv3core.dycore_state import DycoreState
 from pace.util.grid import GridData
-
-
-class MetaEnumStr(EnumMeta):
-    def __contains__(cls, item):
-        return item in cls.__members__.keys()
 
 
 class Cases(Enum, metaclass=MetaEnumStr):

--- a/fv3core/pace/fv3core/initialization/analytic_init.py
+++ b/fv3core/pace/fv3core/initialization/analytic_init.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 import pace.util as fv3util
-from pace.util import MetaEnumStr
 from pace.fv3core.dycore_state import DycoreState
+from pace.util import MetaEnumStr
 from pace.util.grid import GridData
 
 

--- a/physics/pace/physics/__init__.py
+++ b/physics/pace/physics/__init__.py
@@ -1,4 +1,4 @@
-from ._config import PhysicsConfig
+from ._config import PHYSICS_PACKAGES, PhysicsConfig
 from .physics_state import PhysicsState
 from .stencils.microphysics import Microphysics
 from .stencils.physics import Physics

--- a/physics/pace/physics/_config.py
+++ b/physics/pace/physics/_config.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import f90nml
 
@@ -18,7 +18,7 @@ class PhysicsConfig:
     npy: int = DEFAULT_INT
     npz: int = DEFAULT_INT
     nwat: int = DEFAULT_INT
-    schemes: list[str] = ["gfs_microphysics"]
+    schemes: List[str] = ["GFS_microphysics"]
     do_qa: bool = DEFAULT_BOOL
     c_cracw: float = NamelistDefaults.c_cracw
     c_paut: float = NamelistDefaults.c_paut

--- a/physics/pace/physics/_config.py
+++ b/physics/pace/physics/_config.py
@@ -18,6 +18,7 @@ class PhysicsConfig:
     npy: int = DEFAULT_INT
     npz: int = DEFAULT_INT
     nwat: int = DEFAULT_INT
+    schemes: list[str] = ["gfs_microphysics"]
     do_qa: bool = DEFAULT_BOOL
     c_cracw: float = NamelistDefaults.c_cracw
     c_paut: float = NamelistDefaults.c_paut

--- a/physics/pace/physics/_config.py
+++ b/physics/pace/physics/_config.py
@@ -8,6 +8,7 @@ from pace.util import Namelist, NamelistDefaults
 
 DEFAULT_INT = 0
 DEFAULT_BOOL = False
+DEFAULT_SCHEMES = ["GFS_microphysics"]
 
 
 @dataclasses.dataclass
@@ -18,7 +19,7 @@ class PhysicsConfig:
     npy: int = DEFAULT_INT
     npz: int = DEFAULT_INT
     nwat: int = DEFAULT_INT
-    schemes: List[str] = ["GFS_microphysics"]
+    schemes: List[str] = None
     do_qa: bool = DEFAULT_BOOL
     c_cracw: float = NamelistDefaults.c_cracw
     c_paut: float = NamelistDefaults.c_paut
@@ -101,6 +102,8 @@ class PhysicsConfig:
     namelist_override: Optional[str] = None
 
     def __post_init__(self):
+        if self.schemes is None:
+            self.schemes = DEFAULT_SCHEMES
         if self.namelist_override is not None:
             try:
                 f90_nml = f90nml.read(self.namelist_override)

--- a/physics/pace/physics/_config.py
+++ b/physics/pace/physics/_config.py
@@ -25,7 +25,7 @@ class PhysicsConfig:
     npy: int = DEFAULT_INT
     npz: int = DEFAULT_INT
     nwat: int = DEFAULT_INT
-    schemes: List[PHYSICS_PACKAGES] = None
+    schemes: List = None
     do_qa: bool = DEFAULT_BOOL
     c_cracw: float = NamelistDefaults.c_cracw
     c_paut: float = NamelistDefaults.c_paut
@@ -110,6 +110,12 @@ class PhysicsConfig:
     def __post_init__(self):
         if self.schemes is None:
             self.schemes = DEFAULT_SCHEMES
+        package_schemes = []
+        for scheme in self.schemes:
+            if scheme not in PHYSICS_PACKAGES:
+                raise NotImplementedError(f"{scheme} physics scheme not implemented")
+            package_schemes.append(PHYSICS_PACKAGES[scheme])
+        self.schemes = package_schemes
         if self.namelist_override is not None:
             try:
                 f90_nml = f90nml.read(self.namelist_override)

--- a/physics/pace/physics/_config.py
+++ b/physics/pace/physics/_config.py
@@ -1,14 +1,20 @@
 import dataclasses
+from enum import Enum, unique
 from typing import List, Optional, Tuple
 
 import f90nml
 
-from pace.util import Namelist, NamelistDefaults
+from pace.util import MetaEnumStr, Namelist, NamelistDefaults
 
 
 DEFAULT_INT = 0
 DEFAULT_BOOL = False
 DEFAULT_SCHEMES = ["GFS_microphysics"]
+
+
+@unique
+class PHYSICS_PACKAGES(Enum, metaclass=MetaEnumStr):
+    GFS_microphysics = "GFS_microphysics"
 
 
 @dataclasses.dataclass
@@ -19,7 +25,7 @@ class PhysicsConfig:
     npy: int = DEFAULT_INT
     npz: int = DEFAULT_INT
     nwat: int = DEFAULT_INT
-    schemes: List[str] = None
+    schemes: List[PHYSICS_PACKAGES] = None
     do_qa: bool = DEFAULT_BOOL
     c_cracw: float = NamelistDefaults.c_cracw
     c_paut: float = NamelistDefaults.c_paut

--- a/physics/pace/physics/physics_state.py
+++ b/physics/pace/physics/physics_state.py
@@ -287,7 +287,7 @@ class PhysicsState:
         self, quantity_factory: pace.util.QuantityFactory, schemes: List[str]
     ):
         # storage for tendency variables not in PhysicsState
-        if "microphysics" in schemes:
+        if "GFS_microphysics" in schemes:
             tendency = quantity_factory.zeros(
                 [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
                 "unknown",
@@ -352,9 +352,7 @@ class PhysicsState:
                     extent=sizer.get_extent(dims),
                 )
                 inputs[_field.name] = quantity
-        return cls(
-            **inputs, quantity_factory=quantity_factory, schemes=schemes
-        )
+        return cls(**inputs, quantity_factory=quantity_factory, schemes=schemes)
 
     @property
     def xr_dataset(self):

--- a/physics/pace/physics/physics_state.py
+++ b/physics/pace/physics/physics_state.py
@@ -281,13 +281,13 @@ class PhysicsState:
         }
     )
     quantity_factory: InitVar[pace.util.QuantityFactory]
-    active_packages: InitVar[List[str]]
+    schemes: InitVar[List[str]]
 
     def __post_init__(
-        self, quantity_factory: pace.util.QuantityFactory, active_packages: List[str]
+        self, quantity_factory: pace.util.QuantityFactory, schemes: List[str]
     ):
         # storage for tendency variables not in PhysicsState
-        if "microphysics" in active_packages:
+        if "microphysics" in schemes:
             tendency = quantity_factory.zeros(
                 [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
                 "unknown",
@@ -317,7 +317,7 @@ class PhysicsState:
             self.microphysics = None
 
     @classmethod
-    def init_zeros(cls, quantity_factory, active_packages: List[str]) -> "PhysicsState":
+    def init_zeros(cls, quantity_factory, schemes: List[str]) -> "PhysicsState":
         initial_arrays = {}
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
@@ -329,7 +329,7 @@ class PhysicsState:
         return cls(
             **initial_arrays,
             quantity_factory=quantity_factory,
-            active_packages=active_packages,
+            schemes=schemes,
         )
 
     @classmethod
@@ -338,7 +338,7 @@ class PhysicsState:
         storages: Mapping[str, Any],
         sizer: pace.util.GridSizer,
         quantity_factory: pace.util.QuantityFactory,
-        active_packages: List[str],
+        schemes: List[str],
     ) -> "PhysicsState":
         inputs: Dict[str, pace.util.Quantity] = {}
         for _field in fields(cls):
@@ -353,14 +353,14 @@ class PhysicsState:
                 )
                 inputs[_field.name] = quantity
         return cls(
-            **inputs, quantity_factory=quantity_factory, active_packages=active_packages
+            **inputs, quantity_factory=quantity_factory, schemes=schemes
         )
 
     @property
     def xr_dataset(self):
         data_vars = {}
         for name, field_info in self.__dataclass_fields__.items():
-            if name not in ["quantity_factory", "active_packages"]:
+            if name not in ["quantity_factory", "schemes"]:
                 if issubclass(field_info.type, pace.util.Quantity):
                     dims = [
                         f"{dim_name}_{name}" for dim_name in field_info.metadata["dims"]

--- a/physics/pace/physics/physics_state.py
+++ b/physics/pace/physics/physics_state.py
@@ -8,6 +8,8 @@ import pace.util
 from pace.dsl.typing import Float
 from pace.physics.stencils.microphysics import MicrophysicsState
 
+from .config import PHYSICS_PACKAGES
+
 
 @dataclass()
 class PhysicsState:
@@ -281,10 +283,12 @@ class PhysicsState:
         }
     )
     quantity_factory: InitVar[pace.util.QuantityFactory]
-    schemes: InitVar[List[str]]
+    schemes: InitVar[List[PHYSICS_PACKAGES]]
 
     def __post_init__(
-        self, quantity_factory: pace.util.QuantityFactory, schemes: List[str]
+        self,
+        quantity_factory: pace.util.QuantityFactory,
+        schemes: List[PHYSICS_PACKAGES],
     ):
         # storage for tendency variables not in PhysicsState
         if "GFS_microphysics" in schemes:
@@ -317,7 +321,9 @@ class PhysicsState:
             self.microphysics = None
 
     @classmethod
-    def init_zeros(cls, quantity_factory, schemes: List[str]) -> "PhysicsState":
+    def init_zeros(
+        cls, quantity_factory, schemes: List[PHYSICS_PACKAGES]
+    ) -> "PhysicsState":
         initial_arrays = {}
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
@@ -338,7 +344,7 @@ class PhysicsState:
         storages: Mapping[str, Any],
         sizer: pace.util.GridSizer,
         quantity_factory: pace.util.QuantityFactory,
-        schemes: List[str],
+        schemes: List[PHYSICS_PACKAGES],
     ) -> "PhysicsState":
         inputs: Dict[str, pace.util.Quantity] = {}
         for _field in fields(cls):

--- a/physics/pace/physics/physics_state.py
+++ b/physics/pace/physics/physics_state.py
@@ -8,7 +8,7 @@ import pace.util
 from pace.dsl.typing import Float
 from pace.physics.stencils.microphysics import MicrophysicsState
 
-from .config import PHYSICS_PACKAGES
+from ._config import PHYSICS_PACKAGES
 
 
 @dataclass()
@@ -291,7 +291,7 @@ class PhysicsState:
         schemes: List[PHYSICS_PACKAGES],
     ):
         # storage for tendency variables not in PhysicsState
-        if "GFS_microphysics" in schemes:
+        if "GFS_microphysics" in [scheme.value for scheme in schemes]:
             tendency = quantity_factory.zeros(
                 [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
                 "unknown",

--- a/physics/pace/physics/stencils/physics.py
+++ b/physics/pace/physics/stencils/physics.py
@@ -27,7 +27,7 @@ from .._config import PhysicsConfig
 
 
 class PHYSICS_PACKAGES(Enum, metaclass=pace.util.MetaEnumStr):
-    microphysics = "GFS_microphysics"
+    GFS_microphysics = "GFS_microphysics"
 
 
 def atmos_phys_driver_statein(

--- a/physics/pace/physics/stencils/physics.py
+++ b/physics/pace/physics/stencils/physics.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import List
 
 import gt4py.cartesian.gtscript as gtscript
@@ -27,8 +28,8 @@ from pace.util.grid import GridData
 from .._config import PhysicsConfig
 
 
-PHYSICS_PACKAGES = Literal["microphysics"]
-
+class PHYSICS_PACKAGES(Enum, metaclass=pace.util.MetaEnumStr):
+    microphysics = "microphysics"
 
 def atmos_phys_driver_statein(
     prsik: FloatField,
@@ -208,8 +209,13 @@ class Physics:
         quantity_factory: pace.util.QuantityFactory,
         grid_data: GridData,
         namelist: PhysicsConfig,
-        active_packages: List[Literal[PHYSICS_PACKAGES]],
+        schemes: list[str],
     ):
+        for scheme in schemes:
+            if scheme not in PHYSICS_PACKAGES:
+                raise NotImplementedError(
+                    f"{scheme} is not an implemented physics parameterization"
+                )
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
@@ -249,7 +255,7 @@ class Physics:
                 "pktop": self._pktop,
             },
         )
-        if "microphysics" in active_packages:
+        if "microphysics" in schemes:
             self._do_microphysics = True
             self._prepare_microphysics = stencil_factory.from_origin_domain(
                 func=prepare_microphysics,

--- a/physics/pace/physics/stencils/physics.py
+++ b/physics/pace/physics/stencils/physics.py
@@ -203,7 +203,7 @@ class Physics:
         grid_data: GridData,
         namelist: PhysicsConfig,
     ):
-        schemes = namelist.schemes
+        schemes = [scheme.value for scheme in namelist.schemes]
         for scheme in schemes:
             if scheme not in PHYSICS_PACKAGES:
                 raise NotImplementedError(

--- a/physics/pace/physics/stencils/physics.py
+++ b/physics/pace/physics/stencils/physics.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 import gt4py.cartesian.gtscript as gtscript
 from gt4py.cartesian.gtscript import (
     BACKWARD,
@@ -23,11 +21,7 @@ from pace.physics.stencils.microphysics import Microphysics
 from pace.util import X_DIM, Y_DIM, Z_DIM
 from pace.util.grid import GridData
 
-from .._config import PhysicsConfig
-
-
-class PHYSICS_PACKAGES(Enum, metaclass=pace.util.MetaEnumStr):
-    GFS_microphysics = "GFS_microphysics"
+from .._config import PHYSICS_PACKAGES, PhysicsConfig
 
 
 def atmos_phys_driver_statein(

--- a/physics/tests/savepoint/translate/translate_driver.py
+++ b/physics/tests/savepoint/translate/translate_driver.py
@@ -43,7 +43,7 @@ class TranslateDriver(TranslateFVDynamics):
             sizer, backend=self.stencil_config.compilation_config.backend
         )
         physics_state = PhysicsState.init_zeros(
-            quantity_factory=quantity_factory, schemes=["microphysics"]
+            quantity_factory=quantity_factory, schemes=["GFS_microphysics"]
         )
         tendency_state = TendencyState.init_zeros(
             quantity_factory=quantity_factory,

--- a/physics/tests/savepoint/translate/translate_driver.py
+++ b/physics/tests/savepoint/translate/translate_driver.py
@@ -43,7 +43,7 @@ class TranslateDriver(TranslateFVDynamics):
             sizer, backend=self.stencil_config.compilation_config.backend
         )
         physics_state = PhysicsState.init_zeros(
-            quantity_factory=quantity_factory, active_packages=["microphysics"]
+            quantity_factory=quantity_factory, schemes=["microphysics"]
         )
         tendency_state = TendencyState.init_zeros(
             quantity_factory=quantity_factory,

--- a/physics/tests/savepoint/translate/translate_driver.py
+++ b/physics/tests/savepoint/translate/translate_driver.py
@@ -8,7 +8,7 @@ from pace.fv3core._config import DynamicalCoreConfig
 # but also, driver tests should not be in physics
 from pace.fv3core.testing.translate_fvdynamics import TranslateFVDynamics
 from pace.fv3core.testing.validation import enable_selective_validation
-from pace.physics import PhysicsConfig, PhysicsState
+from pace.physics import PHYSICS_PACKAGES, PhysicsConfig, PhysicsState
 from pace.util.namelist import Namelist
 
 
@@ -43,7 +43,8 @@ class TranslateDriver(TranslateFVDynamics):
             sizer, backend=self.stencil_config.compilation_config.backend
         )
         physics_state = PhysicsState.init_zeros(
-            quantity_factory=quantity_factory, schemes=["GFS_microphysics"]
+            quantity_factory=quantity_factory,
+            schemes=[PHYSICS_PACKAGES["GFS_microphysics"]],
         )
         tendency_state = TendencyState.init_zeros(
             quantity_factory=quantity_factory,

--- a/physics/tests/savepoint/translate/translate_gfs_physics_driver.py
+++ b/physics/tests/savepoint/translate/translate_gfs_physics_driver.py
@@ -2,6 +2,7 @@ import copy
 
 import pace.dsl.gt4py_utils as utils
 import pace.util as util
+from pace.physics import PHYSICS_PACKAGES
 from pace.physics.stencils.physics import Physics, PhysicsState
 from pace.stencils import update_atmos_state
 from pace.stencils.testing.translate_physics import TranslatePhysicsFortranData2Py
@@ -129,7 +130,7 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
         quantity_factory = util.QuantityFactory.from_backend(
             sizer, self.stencil_factory.backend
         )
-        schemes = ["GFS_microphysics"]
+        schemes = [PHYSICS_PACKAGES["GFS_microphysics"]]
         physics_state = PhysicsState(
             **inputs,
             quantity_factory=quantity_factory,

--- a/physics/tests/savepoint/translate/translate_gfs_physics_driver.py
+++ b/physics/tests/savepoint/translate/translate_gfs_physics_driver.py
@@ -129,18 +129,17 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
         quantity_factory = util.QuantityFactory.from_backend(
             sizer, self.stencil_factory.backend
         )
-        active_packages = ["microphysics"]
+        schemes = ["GFS_microphysics"]
         physics_state = PhysicsState(
             **inputs,
             quantity_factory=quantity_factory,
-            active_packages=active_packages,
+            schemes=schemes,
         )
         physics = Physics(
             self.stencil_factory,
             self.grid.quantity_factory,
             self.grid.grid_data,
             self.namelist,
-            active_packages=active_packages,
         )
         # TODO, self.namelist doesn't have fv_sg_adj because it is PhysicsConfig
         # either move where GFSPhysicsDriver starts, or pass the full namelist or

--- a/physics/tests/savepoint/translate/translate_microphysics.py
+++ b/physics/tests/savepoint/translate/translate_microphysics.py
@@ -88,7 +88,7 @@ class TranslateMicroph(TranslatePhysicsFortranData2Py):
             inputs,
             sizer=sizer,
             quantity_factory=quantity_factory,
-            active_packages=["microphysics"],
+            schemes=["GFS_microphysics"],
         )
         microphysics = Microphysics(
             self.stencil_factory, quantity_factory, self.grid.grid_data, self.namelist

--- a/physics/tests/savepoint/translate/translate_microphysics.py
+++ b/physics/tests/savepoint/translate/translate_microphysics.py
@@ -5,6 +5,7 @@ import numpy as np
 import pace.dsl.gt4py_utils as utils
 import pace.util
 from pace.dsl.typing import Float
+from pace.physics import PHYSICS_PACKAGES
 from pace.physics.stencils.microphysics import Microphysics
 from pace.physics.stencils.physics import PhysicsState
 from pace.stencils.testing.translate_physics import TranslatePhysicsFortranData2Py
@@ -88,7 +89,7 @@ class TranslateMicroph(TranslatePhysicsFortranData2Py):
             inputs,
             sizer=sizer,
             quantity_factory=quantity_factory,
-            schemes=["GFS_microphysics"],
+            schemes=[PHYSICS_PACKAGES["GFS_microphysics"]],
         )
         microphysics = Microphysics(
             self.stencil_factory, quantity_factory, self.grid.grid_data, self.namelist

--- a/tests/main/driver/test_example_configs.py
+++ b/tests/main/driver/test_example_configs.py
@@ -14,6 +14,7 @@ EXAMPLE_CONFIGS_DIR = os.path.join(dirname, "../../../driver/examples/configs/")
 TESTED_CONFIGS: List[str] = [
     "baroclinic_c12.yaml",
     "baroclinic_c12_dp.yaml",
+    "baroclinic_c12_explicit_physics.yaml",
     "baroclinic_c12_comm_read.yaml",
     "baroclinic_c12_comm_write.yaml",
     "baroclinic_c12_null_comm.yaml",

--- a/tests/main/driver/test_restart_fortran.py
+++ b/tests/main/driver/test_restart_fortran.py
@@ -58,6 +58,7 @@ def test_state_from_fortran_restart():
         damping_coefficients=damping_coefficients,
         driver_grid_data=driver_grid_data,
         grid_data=grid_data,
+        schemes=["GFS_microphysics"],
     )
     ds = xr.open_dataset(os.path.join(restart_dir, "fv_core.res.tile1.nc"))
     np.testing.assert_array_equal(

--- a/tests/main/driver/test_restart_fortran.py
+++ b/tests/main/driver/test_restart_fortran.py
@@ -6,6 +6,7 @@ import xarray as xr
 import pace.driver
 import pace.util
 from pace.driver.initialization import FortranRestartInit
+from pace.physics import PHYSICS_PACKAGES
 from pace.util import (
     CubedSphereCommunicator,
     CubedSpherePartitioner,
@@ -58,7 +59,7 @@ def test_state_from_fortran_restart():
         damping_coefficients=damping_coefficients,
         driver_grid_data=driver_grid_data,
         grid_data=grid_data,
-        schemes=["GFS_microphysics"],
+        schemes=[PHYSICS_PACKAGES["GFS_microphysics"]],
     )
     ds = xr.open_dataset(os.path.join(restart_dir, "fv_core.res.tile1.nc"))
     np.testing.assert_array_equal(

--- a/tests/main/driver/test_restart_serial.py
+++ b/tests/main/driver/test_restart_serial.py
@@ -10,6 +10,7 @@ import pace.dsl
 from pace.driver import CreatesComm, DriverConfig
 from pace.driver.driver import RestartConfig
 from pace.driver.initialization import AnalyticInit
+from pace.physics import PHYSICS_PACKAGES
 from pace.util.null_comm import NullComm
 
 
@@ -78,7 +79,7 @@ def test_restart_save_to_disk():
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
-            schemes=["GFS_microphysics"],
+            schemes=[PHYSICS_PACKAGES["GFS_microphysics"]],
         )
         time = datetime(2016, 1, 1, 0, 0, 0)
 

--- a/tests/main/driver/test_restart_serial.py
+++ b/tests/main/driver/test_restart_serial.py
@@ -78,6 +78,7 @@ def test_restart_save_to_disk():
             damping_coefficients=damping_coefficients,
             driver_grid_data=driver_grid_data,
             grid_data=grid_data,
+            schemes=["GFS_microphysics"],
         )
         time = datetime(2016, 1, 1, 0, 0, 0)
 

--- a/tests/main/physics/test_integration.py
+++ b/tests/main/physics/test_integration.py
@@ -73,7 +73,7 @@ def setup_physics():
         physics_config,
     )
     physics_state = pace.physics.PhysicsState.init_zeros(
-        quantity_factory, schemes=["GFS_microphysics"]
+        quantity_factory, schemes=[pace.physics.PHYSICS_PACKAGES["GFS_microphysics"]]
     )
     random = np.random.RandomState(0)
     for field in fields(pace.physics.PhysicsState):

--- a/tests/main/physics/test_integration.py
+++ b/tests/main/physics/test_integration.py
@@ -71,10 +71,9 @@ def setup_physics():
         quantity_factory,
         grid_data,
         physics_config,
-        active_packages=["microphysics"],
     )
     physics_state = pace.physics.PhysicsState.init_zeros(
-        quantity_factory, active_packages=["microphysics"]
+        quantity_factory, schemes=["GFS_microphysics"]
     )
     random = np.random.RandomState(0)
     for field in fields(pace.physics.PhysicsState):

--- a/util/HISTORY.md
+++ b/util/HISTORY.md
@@ -4,6 +4,7 @@ History
 latest
 ------
 
+- Added `MetaEnumStr` to utils to make enums more functional
 - Added `fill_for_translate_test` to MetricTerms to fill fields with NaNs only when required for testing
 - Added `init_cartesian` method to MetricTerms to handle grid generation for orthogonal grids
 - Added `from_layout` and `size` methods to TileCommunicator and Communicator

--- a/util/pace/util/__init__.py
+++ b/util/pace/util/__init__.py
@@ -70,6 +70,7 @@ from .partitioner import (
 from .quantity import Quantity, QuantityMetadata
 from .time import FMS_TO_CFTIME_TYPE, datetime64_to_datetime
 from .units import UnitsError, ensure_equal_units, units_are_equal
+from .utils import MetaEnumStr
 
 
 __version__ = "0.10.0"

--- a/util/pace/util/utils.py
+++ b/util/pace/util/utils.py
@@ -1,5 +1,5 @@
 from enum import EnumMeta
-from typing import Any, Iterable, Sequence, Tuple, TypeVar, Union
+from typing import Iterable, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 

--- a/util/pace/util/utils.py
+++ b/util/pace/util/utils.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Sequence, Tuple, TypeVar, Union
+from enum import EnumMeta
+from typing import Any, Iterable, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 
@@ -19,6 +20,11 @@ else:
     GPU_AVAILABLE = False
 
 T = TypeVar("T")
+
+
+class MetaEnumStr(EnumMeta):
+    def __contains__(cls, item) -> bool:
+        return item in cls.__members__.keys()
 
 
 def list_by_dims(


### PR DESCRIPTION
## Purpose

Currently the enabled physics schemes are hardcoded into an "active_packages" list at multiple points in the code. This PR changes that to be set in the physics config in order to enable more physics schemes to be integrated into the model and make this more adaptable.

## Code changes:

- docs/physics/state.rst: PhysicsState now takes schemes as an argument, which comes from the PhysicsConfig
- driver/pace/driver/driver.py: get_driver_state now takes schemes as an input in order to pass schemes along to PhysicsState
- driver/pace/driver/initialization.py: all get_driver_state functions now take schemes as an input in order to pass schemes along to PhysicsState
- driver/pace/driver/state.py: PhysicsState needs the active physics schemes in order to initialize, so it is now in the call signature for restart_driver_state and load_state_from_restart
- fv3core/pace/fv3core/initialization/analytic_init.py: MetaEnumStr lives in utils now
- physics/pace/physics/_config.py: schemes is now a member of the config class, with a default value of `["GFS_microphysics"]`
- physics/pace/physics/physics_state.py: renamed "active_packages" to "schemes" and "microphysics" to "GFS_microphysics" in preparation for the SHiELD microphysics to be integrated
- physics/pace/physics/stencils/physics.py: Possible physics schemes is an enum class now, changed "active_packages" to "schemes" and "microphysics" to "GFS_microphysics"
-  physics/tests/savepoint/translate/translate_driver.py: changed "active_packages" to "schemes" and "microphysics" to "GFS_microphysics"
- physics/tests/savepoint/translate/translate_gfs_physics_driver.py: changed "active_packages" to "schemes" and "microphysics" to "GFS_microphysics"
- physics/tests/savepoint/translate/translate_microphysics.py: changed "active_packages" to "schemes" and "microphysics" to "GFS_microphysics"
- tests/main/driver/test_restart_fortran.py: added schemes to call for get_driver_state
- tests/main/driver/test_restart_serial.py: added schemes to call for get_driver_state
- tests/main/physics/test_integration.py: changed "active_packages" to "schemes" and "microphysics" to "GFS_microphysics"
- util/pace/util/utils.py: Added MetaEnumStr

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes