### PR TITLE
fix mpi4py version

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -49,7 +49,7 @@ ENV CFLAGS="-I/usr/include -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1"
 RUN python3 -m pip install \
     numpy==1.21.2 \
     netCDF4==1.5.7 \
-    mpi4py==3.1.0 \
+    mpi4py==3.1.1 \
     matplotlib==3.5.2 \
     ipyparallel==8.4.1 \
     jupyterlab==3.4.4 \


### PR DESCRIPTION
## Purpose

This PR fixes the version of mpi4py installed in the examples docker image so that we can run notebooks successfully

## Code changes:

- examples/Dockerfile: mpi4py version updated to 3.1.1 --3.1.0 caused conflicts

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes