### PR TITLE
change url address to https address in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 
 [submodule "NDSL"]
 	path = NDSL
-	url = git@github.com:NOAA-GFDL/NDSL.git
+	url = https://github.com/NOAA-GFDL/NDSL.git
 [submodule "pyFV3"]
 	path = pyFV3
-	url = git@github.com:NOAA-GFDL/PyFV3.git
+	url = https://github.com/NOAA-GFDL/PyFV3.git
 [submodule "pySHiELD"]
 	path = pySHiELD
-	url = git@github.com:NOAA-GFDL/PySHiELD.git
+	url = https://github.com/NOAA-GFDL/PySHiELD.git


### PR DESCRIPTION
## Purpose

Currently, due to ssh url specifications in the .gitmodules file, users cannot clone pace without having to set up SSH keys.
Cloning pace should be accessible and the .gitmodules file should be modified with  https urls. 

## Code changes:

The urls specified in .gitmodules have been changed from ssh to https address 

## Requirements changes:
N/A

## Infrastructure changes:
N/A

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [x] The names of all the new contributors have been added to CONTRIBUTORS.md
