### PR TITLE
hotfix for ntiles in driver dycore config for doubly periodic runs

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -280,6 +280,8 @@ class DriverConfig:
             # Copy grid_type to the DycoreConfig if it's not the default value
             if grid_type != 0:
                 kwargs["dycore_config"].grid_type = grid_type
+                if grid_type > 3:
+                    kwargs["dycore_config"].ntiles = 1
 
         if (
             isinstance(kwargs["stencil_config"], dict)


### PR DESCRIPTION
## Purpose

This fixes the ntiles attribute of dycore config for doubly-periodic configurations, which was always set to 6 before

## Code changes:

- `driver/pace/driver/driver.py`: ntiles attribute of dycore config is now set to 1 for doubly periodic grid setups

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
