### PR TITLE
Fix Dockerfile Module Versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,6 @@ RUN cd / && \
 ENV CFLAGS="-I/usr/include -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1"
 
 RUN python3 -m pip install \
-    numpy==1.21.2 \
-    netCDF4==1.5.7 \
-    mpi4py==3.1.1 \
     matplotlib==3.5.2 \
     ipyparallel==8.4.1 \
     jupyterlab==3.4.4 \


### PR DESCRIPTION
**Description**
The dockerfile reinstalls some python modules (numpy, mpi4py and netcdf) with specific versions hardcoded, and the netcdf4 and numpy versions are incompatible. None of these reinstalls are necessary anyway so I'm taking them out of the dockerfile.

Fixes # (issue)
Didn't log it, sorry

**How Has This Been Tested?**
Checked that everything runs from a fresh docker image build

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
