### PR TITLE
add build script for intel oneapi and gcc compiler separately

### DIFF
--- a/examples/build_scripts/build_gaea_c5_gcc.sh
+++ b/examples/build_scripts/build_gaea_c5_gcc.sh
@@ -26,7 +26,7 @@ git clone --recursive https://github.com/NOAA-GFDL/pace
 cd pace
 
 # create a conda environment for pace
-conda create -y --name my_name python=3.8
+conda create -y --name my_name python=3.11.9
 
 # enter the environment and update it
 conda activate my_name

--- a/examples/build_scripts/build_gaea_c5_gcc.sh
+++ b/examples/build_scripts/build_gaea_c5_gcc.sh
@@ -10,14 +10,14 @@ module load PrgEnv-gnu
 module rm gcc
 module load gcc/12.2.0
 module load boost/1.79.0
-module load python/3.9
+module load python/3.11.7
 
 export CC=`which gcc`
 export CXX=`which g++`
 export MPICC=`which mpicc`
 export MPICXX=`which mpicxx`
 export DACE_compiler_cpu_executable=${CXX}
-export GT4PY_EXTRA_COMPILE_ARGS="-O3 -ffast-math -fprefetch-loop-arrays -flto=thin -funroll-all-loops"
+export GT4PY_EXTRA_COMPILE_ARGS="-O3 -ffast-math -fprefetch-loop-arrays -funroll-all-loops"
 export OPENMP_CPPFLAGS="-fopenmp -fopenmp-simd"
 export OPENMP_LDFLAGS="-fopenmp -fopenmp-simd"
 
@@ -26,7 +26,7 @@ git clone --recursive https://github.com/NOAA-GFDL/pace
 cd pace
 
 # create a conda environment for pace
-conda create -y --name my_name python=3.11.9
+conda create -y --name my_name python=3.11.7
 
 # enter the environment and update it
 conda activate my_name

--- a/examples/build_scripts/build_gaea_c5_gcc.sh
+++ b/examples/build_scripts/build_gaea_c5_gcc.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Example bash script to install Pace to run bare-metal on Gaea's c4 cluster
+
+set -e -x
+
+# module load necessary system software
+module rm PrgEnv-intel
+module load PrgEnv-gnu
+module rm gcc
+module load gcc/12.2.0
+module load boost/1.79.0
+module load python/3.9
+
+export CC=`which gcc`
+export CXX=`which g++`
+export MPICC=`which mpicc`
+export MPICXX=`which mpicxx`
+export DACE_compiler_cpu_executable=${CXX}
+export GT4PY_EXTRA_COMPILE_ARGS="-O3 -ffast-math -fprefetch-loop-arrays -flto=thin -funroll-all-loops"
+export OPENMP_CPPFLAGS="-fopenmp -fopenmp-simd"
+export OPENMP_LDFLAGS="-fopenmp -fopenmp-simd"
+
+# clone Pace and update submodules
+git clone --recursive https://github.com/NOAA-GFDL/pace
+cd pace
+
+# create a conda environment for pace
+conda create -y --name my_name python=3.8
+
+# enter the environment and update it
+conda activate my_name
+pip3 install --upgrade pip setuptools wheel
+
+# install the Pace dependencies, GT4Py, and Pace
+pip3 install -r requirements_dev.txt -c constraints.txt

--- a/examples/build_scripts/build_ppan_intel.sh
+++ b/examples/build_scripts/build_ppan_intel.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+INSTALL_PREFIX=$1
+ENVIRONMENT_NAME=$2
+
+PACE_DIR=$(pwd)/../..
+FV3NET_DIR=$INSTALL_PREFIX/fv3net
+
+# module load necessary system software
+module load conda
+module load intel_compilers/2021.3.0
+
+export CC=`which icpx`
+export CXX=`which icpx`
+export MPICC=`which mpiicx`
+export MPICXX=`which mpiicpx`
+export DACE_compiler_cpu_executable=${CXX}
+export GT4PY_EXTRA_COMPILE_ARGS="-O3 -funroll-loops -qopt-prefetch=2 -align"
+export OPENMP_CPPFLAGS="-qopenmp -qopenmp-simd"
+export OPENMP_LDFLAGS="-qopenmp -qopenmp-simd"
+
+CONDA_PREFIX=$INSTALL_PREFIX/conda
+conda config --add pkgs_dirs $CONDA_PREFIX/pkgs
+conda config --add envs_dirs $CONDA_PREFIX/envs
+
+# enter the pace directory
+cd $PACE_DIR
+
+# create a conda environment with cartopy and its dependencies installed
+conda create -c conda-forge -y --name $ENVIRONMENT_NAME python=3.8 matplotlib==3.5.2 cartopy==0.18.0
+
+# enter the environment and update it
+conda activate $ENVIRONMENT_NAME
+pip3 install --upgrade --no-cache-dir pip setuptools wheel
+
+# install the Pace dependencies, GT4Py, and Pace
+pip3 install --no-cache-dir -r requirements_dev.txt -c constraints.txt
+
+# clone fv3net
+git clone https://github.com/ai2cm/fv3net.git $FV3NET_DIR
+
+# install jupyter and ipyparallel
+pip3 install --no-cache-dir \
+       ipyparallel==8.4.1 \
+       jupyterlab==3.4.4 \
+       jupyterlab_code_formatter==1.5.2 \
+       isort==5.10.1 \
+       black==22.3.0
+
+# install vcm
+python3 -m pip install $FV3NET_DIR/external/vcm

--- a/examples/build_scripts/build_ppan_intel.sh
+++ b/examples/build_scripts/build_ppan_intel.sh
@@ -29,7 +29,7 @@ conda config --add envs_dirs $CONDA_PREFIX/envs
 cd $PACE_DIR
 
 # create a conda environment with cartopy and its dependencies installed
-conda create -c conda-forge -y --name $ENVIRONMENT_NAME python=3.11.9 matplotlib==3.5.2 cartopy==0.18.0
+conda create -c conda-forge -y --name $ENVIRONMENT_NAME python=3.11.7 matplotlib==3.5.2 cartopy==0.18.0
 
 # enter the environment and update it
 conda activate $ENVIRONMENT_NAME

--- a/examples/build_scripts/build_ppan_intel.sh
+++ b/examples/build_scripts/build_ppan_intel.sh
@@ -29,7 +29,7 @@ conda config --add envs_dirs $CONDA_PREFIX/envs
 cd $PACE_DIR
 
 # create a conda environment with cartopy and its dependencies installed
-conda create -c conda-forge -y --name $ENVIRONMENT_NAME python=3.8 matplotlib==3.5.2 cartopy==0.18.0
+conda create -c conda-forge -y --name $ENVIRONMENT_NAME python=3.11.9 matplotlib==3.5.2 cartopy==0.18.0
 
 # enter the environment and update it
 conda activate $ENVIRONMENT_NAME


### PR DESCRIPTION
**Description**
add build env script for intel oneAPI build and gcc build of Pace with optimization options for loop unroll, and array prefetch.

please note that these options are needed to be incorported in the regression test and container build, with the purpose of supporting various supercomputers in the future. 


Fixes # (issue)
If this is a hotfix to a released version, please specify it.

**How Has This Been Tested?**
The options for Intel compiler are tested using 
Intel(R) oneAPI DPC++/C++ Compiler for applications running on Intel(R) 64, Version 2024.1.0 Build 20240308

and the gcc compiler was tesed using
gcc 13.2

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
