### PR TITLE
Hotfix/update netcdf version for docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y make \
     python3-pip \
     git
 
-RUN pip3 install --upgrade setuptools wheel
+RUN pip3 install --upgrade pip setuptools wheel
 
 COPY . /pace
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -261,7 +261,7 @@ nest-asyncio==1.6.0
     # via
     #   ipykernel
     #   nbclient
-netcdf4==1.7.0
+netcdf4==1.7.1
     # via
     #   -r requirements_dev.txt
     #   ndsl


### PR DESCRIPTION
**Description**
Updates the netcdf4 python version to 1.7.1 which fixes path errors that prevented the docker images from building successfully

**How Has This Been Tested?**
Docker images have been successfully rebuilt after this update

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
