### PR TITLE
Update to `xarray`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -515,7 +515,7 @@ wheel==0.43.0
     # via
     #   astunparse
     #   scikit-build
-xarray==2024.3.0
+xarray==2025.01.2
     # via
     #   -r requirements_dev.txt
     #   ndsl


### PR DESCRIPTION
We need `xarray` to `2025.01.2` to grab the `DataTree` (and some fixes) for new features led in (https://github.com/NOAA-GFDL/NDSL/pull/114).

No changes for Pace