### PR TITLE
Feature: Ability to set desired NetCDF output precision from config

### DIFF
--- a/pace/diagnostics.py
+++ b/pace/diagnostics.py
@@ -86,6 +86,7 @@ class DiagnosticsConfig:
     names: List[str] = dataclasses.field(default_factory=list)
     derived_names: List[str] = dataclasses.field(default_factory=list)
     z_select: List[ZSelect] = dataclasses.field(default_factory=list)
+    precision: str = "Float"
 
     def __post_init__(self):
         if (len(self.names) > 0 or len(self.derived_names) > 0) and self.path is None:
@@ -96,6 +97,11 @@ class DiagnosticsConfig:
             raise ValueError(
                 "output_format must be one of 'zarr' or 'netcdf', "
                 f"got {self.output_format}"
+            )
+        if self.precision not in ["Float", "float32", "float64"]:
+            raise ValueError(
+                "precision must be one of 'Float', 'float32', or 'float64"
+                f"got {self.precision}"
             )
 
     def diagnostics_factory(self, communicator: Communicator) -> Diagnostics:
@@ -124,6 +130,7 @@ class DiagnosticsConfig:
                     path=self.path,
                     communicator=communicator,
                     time_chunk_size=self.time_chunk_size,
+                    precision=self.precision,
                 )
             else:
                 raise ValueError(

--- a/pace/diagnostics.py
+++ b/pace/diagnostics.py
@@ -4,9 +4,12 @@ import warnings
 from datetime import datetime, timedelta
 from typing import List, Optional, Union
 
+import numpy as np
+
 from ndsl import Quantity
 from ndsl.constants import RGRAV, Z_DIM, Z_INTERFACE_DIM
 from ndsl.dsl.dace.orchestration import dace_inhibitor
+from ndsl.dsl.typing import Float
 from ndsl.filesystem import get_fs
 from ndsl.grid import GridData
 from ndsl.monitor import Monitor, ZarrMonitor
@@ -126,11 +129,17 @@ class DiagnosticsConfig:
                     mpi_comm=communicator.comm,
                 )
             elif self.output_format == "netcdf":
+                if self.precision == "Float":
+                    precision = Float
+                elif self.precision == "float32":
+                    precision = np.float32
+                elif self.precision == "float64":
+                    precision = np.float64
                 monitor = NetCDFMonitor(
                     path=self.path,
                     communicator=communicator,
                     time_chunk_size=self.time_chunk_size,
-                    precision=self.precision,
+                    precision=precision,
                 )
             else:
                 raise ValueError(


### PR DESCRIPTION
**Description**
This PR introduces methods for setting the desired precision of output when using the `netcdf` output format. Within a config file, the precision can be specified as follows:
```
diagnostics_config:
  path: output
  output_format: netcdf
  precision: Float | float32 |float64
```

The `Float` option will use whatever is the current value of the `PACE_FLOAT_PRECISION` environment variable for output precision.
The `float32` option will set the output precision to be `numpy.float32`.
The `float64` option will set the output precision to be `numpy.float64`.
The default option is `Float`.
The latter two options allow for instances when the desired run precision, as set by `PACE_FLOAT_PRECISION`, will be different than the required output precision.
If the combination of `float64` is used with `PACE_FLOAT_PRECISION = 32`, a warning will be raised.

**How Has This Been Tested?**
Tested using the current set of unit tests in the workflow CI

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
