### PR TITLE
Don't force `constraints.txt` when running pace tests in external repositories

### DIFF
--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -23,7 +23,7 @@ jobs:
     container:
       image: ghcr.io/noaa-gfdl/miniforge:mpich
     steps:
-        - name: external trigger Checkout pace/develop
+        - name: "External trigger: Checkout pace/develop"
           if:  ${{ inputs.component_trigger }}
           uses: actions/checkout@v4
           with:
@@ -32,7 +32,7 @@ jobs:
             path: pace
             ref: develop
 
-        - name: external trigger Remove existing component in pace/develop
+        - name: "External trigger: Remove existing component in pace/develop"
           if:  ${{ inputs.component_trigger }}
           run: rm -rf ${GITHUB_WORKSPACE}/pace/${{inputs.component_name}}
 
@@ -43,10 +43,20 @@ jobs:
             path: pace/${{inputs.component_name}}
 
         - name: install packages
+          if:  ${{ ! inputs.component_trigger }}
           run: |
             cd ${GITHUB_WORKSPACE}/pace
             pip3 install --upgrade pip setuptools wheel
             pip3 install -r requirements_dev.txt -c constraints.txt
+
+        - name: "External trigger: Install packages"
+          if:  ${{ inputs.component_trigger }}
+          # Ignore `constraints.txt` when running as part of the NDSL pipeline
+          # to avoid false positives in package dependency resolution.
+          run: |
+            cd ${GITHUB_WORKSPACE}/pace
+            pip3 install --upgrade pip setuptools wheel
+            pip3 install -r requirements_dev.txt
 
         - name: prepare input files
           run: |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@
 List format (alphabetical order):  Surname, Name. Employer/Affiliation
 
 * Abbott, Tristan. GFDL.
+* Cattaneo, Roman. NASA.
 * Cheeseman, Mark. Vulcan Inc.
 * Dahm, Johann. Allen Institute for AI.
 * Davis, Eddie. Allen Institute for AI.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ scipy
 nbmake
 mpi4py
 xarray
-zarr
+zarr <3.0.0
 dask
 netCDF4
 cftime


### PR DESCRIPTION
**Description**

NDSL runs pace tests as part of NDSL's CI. These tests currently fail on a PR[^1] because we are bringing in an updated version of gt4py with dependencies that aren't compatible with `constraints.txt`. This will always happen if NDSL updates a dependency. In previous cases, e.g. PR #103, people manually updated `constraints.txt` in `NOAA-GFDL/pace` before being able to merge in `NOAA-GFDL/NDSL`. Since NDSL is a (downstream) dependency of `pace`, this is the wrong way round.

The proposed solution here is to ignore the `constrains.txt` when running as part of the `NDSL` pipelines. This makes sense since then downstream dependencies can update their dependencies without `pace` having to do so until `pace` actually updates `NDSL` (in which case `constrains.txt` should be regenerated). [This run](https://github.com/NOAA-GFDL/NDSL/actions/runs/14031349013/job/39279506895?pr=119) shows that the PR can be unblocked by the proposed changes.

I had to restrict `zarr < 3.0.0` in `requirements_dev.txt` because it has (as expected for a major version release), breaking API changes, which will make our tests fail.

Blocked PR: https://github.com/NOAA-GFDL/NDSL/pull/119

**How Has This Been Tested?**

All good as long as GitHub workflows still run.

**Checklist:**

- [ ] My code follows the style guidelines of this project: N/A
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings: N/A
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A


[^1]: https://github.com/NOAA-GFDL/NDSL/actions/runs/13996303550/job/39192221212?pr=119