### PR TITLE
Change deprecated `np.product()` to `np.prod()`

### DIFF
--- a/tests/main/fv3core/test_selective_validation.py
+++ b/tests/main/fv3core/test_selective_validation.py
@@ -16,8 +16,8 @@ class DummyClass:
 
 
 def check_selective_region_and_values(instance, name, array, domain):
-    validated_gridcells = np.product(domain)
-    total_gridcells = np.product(array.shape)
+    validated_gridcells = np.prod(domain)
+    total_gridcells = np.prod(array.shape)
     assert np.sum(np.isnan(array)) == total_gridcells - validated_gridcells
     validation_subset = instance.subset_output(name, array)
     assert validation_subset.shape == domain


### PR DESCRIPTION
**Description**

Starting numpy 1.25.0[^1], `np.product()` is deprecated and `np.prod()` should be used instead.

This avoids warnings like

```none
   /__w/NDSL/NDSL/pace/tests/main/fv3core/test_selective_validation.py:109: DeprecationWarning: `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `prod` instead.
    check_selective_region_and_values(instance, name, array, domain1)
```

in GitHub Actions.

**How Has This Been Tested?**

Covered by existing tests.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A

[^1]: https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations