### PR TITLE
Update to Dockerfile and Makefile to reflect recent install method changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install --upgrade pip setuptools wheel
 COPY . /pace
 
 RUN cd /pace && \
-    pip3 install .
+    pip3 install .[test]
 
 RUN cd / && \
     git clone https://github.com/ai2cm/fv3net

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install --upgrade pip setuptools wheel
 COPY . /pace
 
 RUN cd /pace && \
-    pip3 install -r /pace/requirements_dev.txt -c /pace/constraints.txt
+    pip3 install .
 
 RUN cd / && \
     git clone https://github.com/ai2cm/fv3net

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cd / && \
 ENV CFLAGS="-I/usr/include -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1"
 
 RUN python3 -m pip install \
-    matplotlib==3.5.2 \
+    matplotlib==3.10.0 \
     ipyparallel==8.4.1 \
     jupyterlab==3.4.4 \
     shapely==1.8.5 \

--- a/Makefile
+++ b/Makefile
@@ -124,12 +124,6 @@ savepoint_tests_mpi: build
 dependencies.svg: dependencies.dot
 	dot -Tsvg $< -o $@
 
-.PHONY: constraints.txt
-constraints.txt: driver/setup.py ndsl/setup.py pyFV3/setup.py pySHiELD/setup.py requirements_docs.txt requirements_lint.txt external/gt4py/setup.cfg requirements_dev.txt
-	pip-compile $^ --output-file constraints.txt
-	sed -i.bak '/\@ git+https/d' constraints.txt
-	rm -f constraints.txt.bak
-
 physics_savepoint_tests: build
 	TARGET=physics $(MAKE) get_test_data
 	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "$(SAVEPOINT_SETUP) && cd $(PACE_PATH) && pytest --data_path=$(EXPERIMENT_DATA_RUN)/physics/ $(TEST_ARGS) $(PHYSICS_THRESH_ARGS) $(PACE_PATH)/physics/tests/savepoint"


### PR DESCRIPTION
**Description**
This PR updates the Dockerfile and Makefile to use the install method, no longer references a `constraints` or `requirements` file.

**How Has This Been Tested?**
Tested using the currently implemented CI.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
