### PR TITLE
refactor: Use `pathlib` for manipulating paths

### DIFF
--- a/changed_from_main.py
+++ b/changed_from_main.py
@@ -8,14 +8,14 @@ This is useful for running tests only on projects that have changed.
 This script should depend only on Python 3.6+ standard libraries.
 """
 import argparse
-import os
 import re
 import subprocess
+from pathlib import Path
 from typing import Any, Dict, Set
 
 
-DIRNAME = os.path.dirname(os.path.abspath(__file__))
-DEPENDENCIES_DOTFILE = os.path.join(DIRNAME, "dependencies.dot")
+DIRNAME = Path(__file__).parent
+DEPENDENCIES_DOTFILE = DIRNAME / "dependencies.dot"
 
 DEFINITION_PATTERN = re.compile(r"\s*([a-zA-Z0-9]+) \[.*label=\"(.*)\".*\]")
 DEPENDENCY_PATTERN = re.compile(r"\s*([a-zA-Z0-9]+) -> ([a-zA-Z0-9]+)")

--- a/pace/comm.py
+++ b/pace/comm.py
@@ -1,7 +1,6 @@
 import abc
 import dataclasses
 import os
-from pathlib import Path
 from typing import Any, ClassVar, List
 
 from ndsl import MPIComm, NullComm
@@ -134,7 +133,7 @@ class WriterCommConfig(CreatesComm):
     """
 
     ranks: List[int]
-    path = Path(".")
+    path: str = "."
 
     def get_comm(self) -> CachingCommWriter:
         underlying = MPICommConfig().get_comm()
@@ -146,7 +145,9 @@ class WriterCommConfig(CreatesComm):
     def cleanup(self, comm: CachingCommWriter):
         os.makedirs(self.path, exist_ok=True)
         if comm.Get_rank() in self.ranks:
-            with open(self.path / f"comm_{comm.Get_rank()}.pkl", "wb") as f:
+            with open(
+                os.path.join(self.path, f"comm_{comm.Get_rank()}.pkl"), "wb"
+            ) as f:
                 comm.dump(f)
 
 
@@ -170,10 +171,10 @@ class ReaderCommConfig(CreatesComm):
     """
 
     rank: int
-    path = Path(".")
+    path: str = "."
 
     def get_comm(self) -> CachingCommReader:
-        with open(self.path / f"comm_{self.rank}.pkl", "rb") as f:
+        with open(os.path.join(self.path, f"comm_{self.rank}.pkl"), "rb") as f:
             return CachingCommReader.load(f)
 
     def cleanup(self, comm: CachingCommWriter):

--- a/pace/comm.py
+++ b/pace/comm.py
@@ -1,6 +1,7 @@
 import abc
 import dataclasses
 import os
+from pathlib import Path
 from typing import Any, ClassVar, List
 
 from ndsl import MPIComm, NullComm
@@ -133,7 +134,7 @@ class WriterCommConfig(CreatesComm):
     """
 
     ranks: List[int]
-    path: str = "."
+    path = Path(".")
 
     def get_comm(self) -> CachingCommWriter:
         underlying = MPICommConfig().get_comm()
@@ -145,9 +146,7 @@ class WriterCommConfig(CreatesComm):
     def cleanup(self, comm: CachingCommWriter):
         os.makedirs(self.path, exist_ok=True)
         if comm.Get_rank() in self.ranks:
-            with open(
-                os.path.join(self.path, f"comm_{comm.Get_rank()}.pkl"), "wb"
-            ) as f:
+            with open(self.path / f"comm_{comm.Get_rank()}.pkl", "wb") as f:
                 comm.dump(f)
 
 
@@ -171,10 +170,10 @@ class ReaderCommConfig(CreatesComm):
     """
 
     rank: int
-    path: str = "."
+    path = Path(".")
 
     def get_comm(self) -> CachingCommReader:
-        with open(os.path.join(self.path, f"comm_{self.rank}.pkl"), "rb") as f:
+        with open(self.path / f"comm_{self.rank}.pkl", "rb") as f:
             return CachingCommReader.load(f)
 
     def cleanup(self, comm: CachingCommWriter):

--- a/pace/configs/comm.py
+++ b/pace/configs/comm.py
@@ -1,7 +1,6 @@
 import abc
 import dataclasses
 import os
-from pathlib import Path
 from typing import Any, ClassVar, List
 
 import dacite
@@ -135,7 +134,7 @@ class WriterCommConfig(CreatesComm):
     """
 
     ranks: List[int]
-    path = Path(".")
+    path: str = "."
 
     def get_comm(self) -> CachingCommWriter:
         underlying = MPICommConfig().get_comm()
@@ -147,7 +146,9 @@ class WriterCommConfig(CreatesComm):
     def cleanup(self, comm: CachingCommWriter):
         os.makedirs(self.path, exist_ok=True)
         if comm.Get_rank() in self.ranks:
-            with open(self.path / f"comm_{comm.Get_rank()}.pkl", "wb") as f:
+            with open(
+                os.path.join(self.path, f"comm_{comm.Get_rank()}.pkl"), "wb"
+            ) as f:
                 comm.dump(f)
 
 
@@ -171,10 +172,10 @@ class ReaderCommConfig(CreatesComm):
     """
 
     rank: int
-    path = Path(".")
+    path: str = "."
 
     def get_comm(self) -> CachingCommReader:
-        with open(self.path / f"comm_{self.rank}.pkl", "rb") as f:
+        with open(os.path.join(self.path, f"comm_{self.rank}.pkl"), "rb") as f:
             return CachingCommReader.load(f)
 
     def cleanup(self, comm: CachingCommWriter):

--- a/pace/configs/comm.py
+++ b/pace/configs/comm.py
@@ -1,6 +1,7 @@
 import abc
 import dataclasses
 import os
+from pathlib import Path
 from typing import Any, ClassVar, List
 
 import dacite
@@ -134,7 +135,7 @@ class WriterCommConfig(CreatesComm):
     """
 
     ranks: List[int]
-    path: str = "."
+    path = Path(".")
 
     def get_comm(self) -> CachingCommWriter:
         underlying = MPICommConfig().get_comm()
@@ -146,9 +147,7 @@ class WriterCommConfig(CreatesComm):
     def cleanup(self, comm: CachingCommWriter):
         os.makedirs(self.path, exist_ok=True)
         if comm.Get_rank() in self.ranks:
-            with open(
-                os.path.join(self.path, f"comm_{comm.Get_rank()}.pkl"), "wb"
-            ) as f:
+            with open(self.path / f"comm_{comm.Get_rank()}.pkl", "wb") as f:
                 comm.dump(f)
 
 
@@ -172,10 +171,10 @@ class ReaderCommConfig(CreatesComm):
     """
 
     rank: int
-    path: str = "."
+    path = Path(".")
 
     def get_comm(self) -> CachingCommReader:
-        with open(os.path.join(self.path, f"comm_{self.rank}.pkl"), "rb") as f:
+        with open(self.path / f"comm_{self.rank}.pkl", "rb") as f:
             return CachingCommReader.load(f)
 
     def cleanup(self, comm: CachingCommWriter):

--- a/pace/grid.py
+++ b/pace/grid.py
@@ -94,7 +94,7 @@ class GeneratedGridConfig(GridInitializer):
     dx_const: Optional[float] = 1000.0
     dy_const: Optional[float] = 1000.0
     deglat: Optional[float] = 15.0
-    eta_file: str = "None"
+    eta_file: Optional[str] = None
 
     def get_grid(
         self,
@@ -214,7 +214,7 @@ class ExternalNetcdfGridConfig(GridInitializer):
     |         |         |
     X----X----X----X----X
 
-    The grid data must define the verticies, centroids, and mid-points
+    The grid data must define the vertices, centroids, and mid-points
     on edge of the cells contained in the computation. For more information
     on grid discretization for the FV3 dynamical core please visit:
     https://www.gfdl.noaa.gov/fv3/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import List
 
@@ -7,7 +6,7 @@ from setuptools import find_namespace_packages, setup
 
 def local_pkg(name: str, relative_path: str) -> str:
     """Returns an absolute path to a local package."""
-    return f"{name} @ file://{Path(os.path.abspath(__file__)).parent / relative_path} "
+    return f"{name} @ file://{Path(__file__).parent / relative_path} "
 
 
 requirements: List[str] = [

--- a/tests/main/driver/test_analytic_init.py
+++ b/tests/main/driver/test_analytic_init.py
@@ -1,19 +1,18 @@
-import os
+from pathlib import Path
 from typing import List
 
 import pytest
 import yaml
 
 from pace import DriverConfig
+from tests.paths import EXAMPLE_CONFIGS_DIR
 
-
-DIR = os.path.dirname(os.path.abspath(__file__))
 
 # TODO: Location of test configurations will be changed after refactor,
 #       need to update after
 
-TESTED_CONFIGS: List[str] = [
-    "../../../examples/configs/analytic_test.yaml",
+TESTED_CONFIGS: List[Path] = [
+    EXAMPLE_CONFIGS_DIR / "analytic_test.yaml",
 ]
 
 
@@ -23,9 +22,9 @@ TESTED_CONFIGS: List[str] = [
         pytest.param(TESTED_CONFIGS, id="example configs"),
     ],
 )
-def test_analytic_init_config(tested_configs: List[str]):
+def test_analytic_init_config(tested_configs: List[Path]):
     for config_file in tested_configs:
-        with open(os.path.join(DIR, config_file), "r") as f:
+        with open(Path(__file__).parent / config_file, "r") as f:
             config = yaml.safe_load(f)
         driver_config = DriverConfig.from_dict(config)
         assert driver_config.initialization.type == "analytic"

--- a/tests/main/driver/test_diagnostics.py
+++ b/tests/main/driver/test_diagnostics.py
@@ -1,21 +1,17 @@
-import os
+from pathlib import Path
 
 import xarray as xr
 import yaml
 
 from pace import DiagnosticsConfig, DriverConfig, NullCommConfig
 from pace.run import main
+from tests.paths import EXAMPLE_CONFIGS_DIR
 
 
-DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-def test_diagnostics_can_be_opened(tmpdir):
-    with open(
-        os.path.join(DIR, "../../../examples/configs/baroclinic_c12.yaml"), "r"
-    ) as f:
+def test_diagnostics_can_be_opened(tmpdir: Path):
+    with open(EXAMPLE_CONFIGS_DIR / "baroclinic_c12.yaml", "r") as f:
         driver_config = DriverConfig.from_dict(yaml.safe_load(f))
-    diagnostics_path = os.path.join(tmpdir, "output.zarr")
+    diagnostics_path = tmpdir / "output.zarr"
     driver_config.diagnostics_config = DiagnosticsConfig(
         path=diagnostics_path,
         names=["u", "v", "ua", "va", "w", "delp", "pt", "qvapor"],

--- a/tests/main/driver/test_example_configs.py
+++ b/tests/main/driver/test_example_configs.py
@@ -1,15 +1,13 @@
 import os
+from pathlib import Path
 from typing import List
 
 import pytest
 import yaml
 
 from pace import DriverConfig
+from tests.paths import EXAMPLE_CONFIGS_DIR, JENKINS_CONFIGS_DIR
 
-
-dirname = os.path.dirname(os.path.abspath(__file__))
-
-EXAMPLE_CONFIGS_DIR = os.path.join(dirname, "../../../examples/configs/")
 
 TESTED_CONFIGS: List[str] = [
     "baroclinic_c12.yaml",
@@ -33,7 +31,7 @@ EXCLUDED_CONFIGS: List[str] = [
     "test_external_C12_2x2.yaml",
 ]
 
-JENKINS_CONFIGS_DIR = os.path.join(dirname, "../../../.jenkins/driver_configs/")
+
 TESTED_JENKINS_CONFIGS: List[str] = [
     "baroclinic_c48_6ranks_dycore_only.yaml",
     "baroclinic_c192_6ranks.yaml",
@@ -62,7 +60,7 @@ EXCLUDED_JENKINS_CONFIGS: List[str] = [
     ],
 )
 def test_all_configs_tested_or_excluded(
-    config_dir: str, tested_configs: List[str], excluded_configs: List[str]
+    config_dir: Path, tested_configs: List[str], excluded_configs: List[str]
 ):
     """
     If any configs are not tested or excluded, add them to TESTED_CONFIGS or
@@ -85,8 +83,8 @@ def test_all_configs_tested_or_excluded(
         pytest.param(JENKINS_CONFIGS_DIR, TESTED_JENKINS_CONFIGS),
     ],
 )
-def test_example_config_can_initialize(path: str, file_list: List[str]):
+def test_example_config_can_initialize(path: Path, file_list: List[str]):
     for file_name in file_list:
-        with open(os.path.join(path, file_name), "r") as f:
+        with open(path / file_name, "r") as f:
             config = DriverConfig.from_dict(yaml.safe_load(f))
         assert isinstance(config, DriverConfig)

--- a/tests/main/driver/test_restart_fortran.py
+++ b/tests/main/driver/test_restart_fortran.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 import xarray as xr
 
@@ -14,10 +12,7 @@ from ndsl import (
 )
 from pace import FortranRestartInit, GeneratedGridConfig
 from pySHiELD import PHYSICS_PACKAGES
-
-
-DIR = os.path.dirname(os.path.abspath(__file__))
-PACE_DIR = os.path.join(DIR, "../../../")
+from tests.paths import REPO_ROOT
 
 
 def test_state_from_fortran_restart():
@@ -42,10 +37,10 @@ def test_state_from_fortran_restart():
     )
 
     quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend="numpy")
-    restart_dir = os.path.join(PACE_DIR, "tests/main/data/c12_restart")
+    restart_dir = REPO_ROOT / "tests" / "main" / "data" / "c12_restart"
 
     (damping_coefficients, driver_grid_data, grid_data,) = GeneratedGridConfig(
-        restart_path=restart_dir, eta_file=restart_dir + "/fv_core.res.nc"
+        restart_path=restart_dir, eta_file=restart_dir / "fv_core.res.nc"
     ).get_grid(quantity_factory, null_communicator)
 
     restart_config = FortranRestartInit(path=restart_dir)
@@ -57,7 +52,7 @@ def test_state_from_fortran_restart():
         grid_data=grid_data,
         schemes=[PHYSICS_PACKAGES["GFS_microphysics"]],
     )
-    ds = xr.open_dataset(os.path.join(restart_dir, "fv_core.res.tile1.nc"))
+    ds = xr.open_dataset(restart_dir / "fv_core.res.tile1.nc")
     np.testing.assert_array_equal(
         ds["u"].values[0, :].transpose(2, 1, 0), driver_state.dycore_state.u.view[:]
     )

--- a/tests/main/driver/test_restart_serial.py
+++ b/tests/main/driver/test_restart_serial.py
@@ -24,9 +24,7 @@ from pace import (
     RestartConfig,
 )
 from pySHiELD import PHYSICS_PACKAGES
-
-
-DIR = os.path.dirname(os.path.abspath(__file__))
+from tests.paths import EXAMPLE_CONFIGS_DIR
 
 
 class NullCommConfig(CreatesComm):
@@ -51,13 +49,7 @@ def test_default_save_restart():
 
 def test_restart_save_to_disk():
     try:
-        with open(
-            os.path.join(
-                DIR,
-                "../../../examples/configs/baroclinic_c12_write_restart.yaml",
-            ),
-            "r",
-        ) as f:
+        with open(EXAMPLE_CONFIGS_DIR / "baroclinic_c12_write_restart.yaml", "r") as f:
             driver_config = DriverConfig.from_dict(yaml.safe_load(f))
         backend = "numpy"
         mpi_comm = NullComm(rank=0, total_ranks=6, fill_value=0.0)
@@ -99,7 +91,7 @@ def test_restart_save_to_disk():
         )
 
         restart_dycore = xr.open_dataset(
-            f"RESTART/restart_dycore_state_{mpi_comm.rank}.nc"
+            Path("RESTART") / f"restart_dycore_state_{mpi_comm.rank}.nc"
         )
         for var in driver_state.dycore_state.__dict__.keys():
             if isinstance(driver_state.dycore_state.__dict__[var], Quantity):
@@ -117,7 +109,7 @@ def test_restart_save_to_disk():
         # TODO: the physics state isn't actually needed in the restart folders as
         # all prognostic state is in dycore state, we could refactor it out
         restart_physics = xr.open_dataset(
-            f"RESTART/restart_physics_state_{mpi_comm.rank}.nc"
+            Path("RESTART") / f"restart_physics_state_{mpi_comm.rank}.nc"
         )
         for var in driver_state.physics_state.__dict__.keys():
             if isinstance(
@@ -135,7 +127,7 @@ def test_restart_save_to_disk():
                             should not be in physics restart file"
                     )
         # test we can use the saved driver config in the restart to load it
-        with open("RESTART/restart.yaml", "r") as f:
+        with open(Path("RESTART") / "restart.yaml", "r") as f:
             restart_config = DriverConfig.from_dict(yaml.safe_load(f))
 
             (

--- a/tests/main/driver/test_restart_serial.py
+++ b/tests/main/driver/test_restart_serial.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 import xarray as xr
@@ -74,7 +75,7 @@ def test_restart_save_to_disk():
         )
         quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
 
-        eta_file = driver_config.grid_config.config.eta_file
+        eta_file = Path(driver_config.grid_config.config.eta_file)
         (damping_coefficients, driver_grid_data, grid_data,) = GeneratedGridConfig(
             eta_file=eta_file
         ).get_grid(quantity_factory, communicator)

--- a/tests/main/fv3core/test_cartesian_grid.py
+++ b/tests/main/fv3core/test_cartesian_grid.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -35,7 +37,7 @@ def test_cartesian_grid_generation(
         dx_const=dx_const,
         dy_const=dy_const,
         deglat=deglat,
-        eta_file="tests/main/input/eta79.nc",
+        eta_file=Path("tests/main/input/eta79.nc"),
     )
     assert np.all(grid_generator.lat_agrid.data == deglat * PI / 180.0)
     assert np.all(grid_generator.lon_agrid.data == 0.0)

--- a/tests/main/fv3core/test_dycore_call.py
+++ b/tests/main/fv3core/test_dycore_call.py
@@ -1,4 +1,3 @@
-import os
 import unittest.mock
 from dataclasses import fields
 from datetime import timedelta
@@ -24,9 +23,6 @@ from ndsl.grid import DampingCoefficients, GridData, MetricTerms
 from ndsl.performance.timer import NullTimer, Timer
 from ndsl.stencils.testing import assert_same_temporaries, copy_temporaries
 from pyFV3 import DycoreState, DynamicalCore, DynamicalCoreConfig
-
-
-DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_dycore() -> Tuple[DynamicalCore, DycoreState, Timer]:

--- a/tests/main/fv3core/test_dycore_call.py
+++ b/tests/main/fv3core/test_dycore_call.py
@@ -2,6 +2,7 @@ import os
 import unittest.mock
 from dataclasses import fields
 from datetime import timedelta
+from pathlib import Path
 from typing import Tuple
 
 import pyFV3.initialization.analytic_init as ai
@@ -100,7 +101,7 @@ def setup_dycore() -> Tuple[DynamicalCore, DycoreState, Timer]:
         sizer=sizer, comm=communicator
     )
     quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
-    eta_file = "tests/main/input/eta79.nc"
+    eta_file = Path("tests/main/input/eta79.nc")
     metric_terms = MetricTerms(
         quantity_factory=quantity_factory,
         communicator=communicator,

--- a/tests/main/physics/test_integration.py
+++ b/tests/main/physics/test_integration.py
@@ -1,5 +1,6 @@
 from dataclasses import fields
 from datetime import timedelta
+from pathlib import Path
 
 import numpy as np
 
@@ -71,7 +72,7 @@ def setup_physics():
     metric_terms = MetricTerms(
         quantity_factory=quantity_factory,
         communicator=communicator,
-        eta_file="tests/main/input/eta79.nc",
+        eta_file=Path("tests/main/input/eta79.nc"),
     )
     grid_data = GridData.new_from_metric_terms(metric_terms)
     physics = Physics(

--- a/tests/main/test_grid_init.py
+++ b/tests/main/test_grid_init.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -37,7 +39,7 @@ def test_grid_init_not_decomposition_dependent(rank: int):
     halo updates for their values in the compute domain.
     """
     nx_tile, ny_tile, nz = 48, 48, 79
-    eta_file = "tests/main/input/eta79.nc"
+    eta_file = Path("tests/main/input/eta79.nc")
     metric_terms_1by1 = MetricTerms(
         quantity_factory=get_quantity_factory(
             layout=(1, 1), nx_tile=nx_tile, ny_tile=ny_tile, nz=nz

--- a/tests/mpi/ext_grid/test_external_grid.py
+++ b/tests/mpi/ext_grid/test_external_grid.py
@@ -1,5 +1,4 @@
 import math
-import os
 
 import numpy as np
 import pytest
@@ -15,11 +14,8 @@ from ndsl import (
 from ndsl.comm.partitioner import get_tile_number
 from ndsl.constants import PI, RADIUS, X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM
 from pace import Driver, DriverConfig
+from tests.paths import EXAMPLE_CONFIGS_DIR, REPO_ROOT
 
-
-DIR = os.path.dirname(os.path.abspath(__file__))
-TEST_CONFIGS_DIR = os.path.join(DIR, "../../../examples/configs/")
-TEST_DATA_DIR = os.path.join(DIR, "../../../test_input/")
 
 TEST_CONFIG_FILE_RANKS = [
     ("test_external_C12_1x1.yaml", 6),
@@ -80,10 +76,7 @@ def test_extgrid_equals_generated(config_file_path: str, ranks: int):
     side = int(math.sqrt(size // 6))
     cube_comm = get_cube_comm(layout=(side, side), comm=comm)
 
-    with open(
-        os.path.join(TEST_CONFIGS_DIR, config_file_path),
-        "r",
-    ) as ext_f:
+    with open(EXAMPLE_CONFIGS_DIR / config_file_path, "r") as ext_f:
         ext_config = yaml.safe_load(ext_f)
         ext_driver_config = DriverConfig.from_dict(ext_config)
 
@@ -91,7 +84,7 @@ def test_extgrid_equals_generated(config_file_path: str, ranks: int):
 
     tile_num = get_tile_num(cube_comm)
     tile_file = TILE_FILE_BASE_NAME + str(tile_num) + ".nc"
-    ds = xr.open_dataset(os.path.join(TEST_DATA_DIR, tile_file))
+    ds = xr.open_dataset(REPO_ROOT / "test_input" / tile_file)
     lon = ds.x.values
     lat = ds.y.values
     dx = ds.dx.values
@@ -188,7 +181,7 @@ def test_extgrid_equals_generated(config_file_path: str, ranks: int):
 
     print(diffs)
 
-    assert not errors, "errors occured in 2x2:\n{}".format("\n".join(errors))
+    assert not errors, "errors occurred in 2x2:\n{}".format("\n".join(errors))
 
     surface_area_true = 4 * PI * (RADIUS ** 2)
 

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent
+
+EXAMPLE_CONFIGS_DIR = REPO_ROOT / "examples" / "configs"
+JENKINS_CONFIGS_DIR = REPO_ROOT / ".jenkins" / "driver_configs"

--- a/tests/savepoint/conftest.py
+++ b/tests/savepoint/conftest.py
@@ -1,9 +1,6 @@
-import os
+from pathlib import Path
 
 import pytest
-
-
-DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.fixture()
@@ -22,7 +19,7 @@ def data_path(pytestconfig):
 def threshold_path(pytestconfig):
     threshold_path = pytestconfig.getoption("threshold_path")
     if threshold_path is None:
-        threshold_path = os.path.join(DIR, "thresholds")
+        threshold_path = Path(__file__).parent / "thresholds"
     return threshold_path
 
 

--- a/tests/savepoint/test_checkpoints.py
+++ b/tests/savepoint/test_checkpoints.py
@@ -1,6 +1,6 @@
 import dataclasses
-import os
 from datetime import timedelta
+from pathlib import Path
 from typing import List, Tuple
 
 import dacite
@@ -35,10 +35,8 @@ from pyFV3 import DycoreState, DynamicalCore, DynamicalCoreConfig
 from pyFV3.testing import TranslateFVDynamics
 
 
-def get_grid(data_path: str, rank: int, layout: Tuple[int, int], backend: str) -> Grid:
-    ds_grid: xr.Dataset = xr.open_dataset(os.path.join(data_path, "Grid-Info.nc")).isel(
-        savepoint=0
-    )
+def get_grid(data_path: Path, rank: int, layout: Tuple[int, int], backend: str) -> Grid:
+    ds_grid: xr.Dataset = xr.open_dataset(data_path / "Grid-Info.nc").isel(savepoint=0)
     grid = TranslateGrid(
         dataset_to_dict(ds_grid.isel(rank=rank)),
         rank=rank,
@@ -64,11 +62,11 @@ class StateInitializer:
 
 
 def test_fv_dynamics(
-    backend: str, data_path: str, calibrate_thresholds: bool, threshold_path: str
+    backend: str, data_path: Path, calibrate_thresholds: bool, threshold_path: Path
 ):
     print("start test call")
-    namelist = Namelist.from_f90nml(f90nml.read(os.path.join(data_path, "input.nml")))
-    threshold_filename = os.path.join(threshold_path, "fv_dynamics.yaml")
+    namelist = Namelist.from_f90nml(f90nml.read(data_path / "input.nml"))
+    threshold_filename = threshold_path / "fv_dynamics.yaml"
     communicator = CubedSphereCommunicator(
         comm=MPIComm(),
         partitioner=CubedSpherePartitioner(
@@ -106,7 +104,7 @@ def test_fv_dynamics(
     translate = TranslateFVDynamics(
         grid=grid, namelist=namelist, stencil_factory=stencil_factory
     )
-    ds = xr.open_dataset(os.path.join(data_path, "FVDynamics-In.nc")).sel(
+    ds = xr.open_dataset(data_path / "FVDynamics-In.nc").sel(
         savepoint=0, rank=communicator.rank
     )
     dycore_config = DynamicalCoreConfig.from_namelist(namelist)


### PR DESCRIPTION
**Description**

Use `pathlib.Path` objects for "eta files" in tests. This is in preparation of NDSL moving towards `pathlib` objects and enforcing them for eta files, see https://github.com/NOAA-GFDL/NDSL/pull/149.

**How Has This Been Tested?**

Running affected tests locally.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
