### PR TITLE
No boost dependency anymore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ commands:
               software-properties-common \
               libopenmpi3 \
               libopenmpi-dev \
-              libboost-all-dev \
               python3 \
               python3-pip \
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && apt-get install -y make \
     libgeos-dev \
     libopenmpi3 \
     libopenmpi-dev \
-    libboost-all-dev \
     libhdf5-serial-dev \
     netcdf-bin \
     libnetcdf-dev \

--- a/README.md
+++ b/README.md
@@ -34,17 +34,6 @@ Pace requires:
 
 For GPU backends CUDA and/or ROCm is required depending on the targeted hardware.
 
-For GT stencils backends, you will also need the headers of the boost libraries in your `$PATH`. This could be down like this.
-
-```shell
-cd BOOST/ROOT
-wget https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz
-tar -xzf boost_1_79_0.tar.gz
-mkdir -p boost_1_79_0/include
-mv boost_1_79_0/boost boost_1_79_0/include/
-export BOOST_ROOT=BOOST/ROOT/boost_1_79_0
-```
-
 When cloning Pace you will need to update the repository's submodules as well:
 
 ```shell

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,18 +20,6 @@ or if you have already cloned the repository:
 
 
 Pace requires GCC > 9.2, MPI, and Python 3.8 on your system, and CUDA is required to run with a GPU backend.
-You will also need the headers of the boost libraries in your `$PATH` (boost itself does not need to be installed).
-If installed outside the standard header locations, gt4py requires that `$BOOST_ROOT` be set:
-
-.. code-block:: console
-
-    $ cd BOOST/ROOT
-    $ wget https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz
-    $ tar -xzf boost_1_79_0.tar.gz
-    $ mkdir -p boost_1_79_0/include
-    $ mv boost_1_79_0/boost boost_1_79_0/include/
-    $ export BOOST_ROOT=BOOST/ROOT/boost_1_79_0
-
 
 We recommend creating a python `venv` or conda environment specifically for Pace.
 

--- a/examples/build_scripts/build_gaea_c4.sh
+++ b/examples/build_scripts/build_gaea_c4.sh
@@ -9,7 +9,6 @@ module rm PrgEnv-intel
 module load PrgEnv-gnu
 module rm gcc
 module load gcc/10.3.0
-module load boost/1.72.0
 module load python/3.9
 
 # clone Pace and update submodules

--- a/examples/build_scripts/build_gaea_c5.sh
+++ b/examples/build_scripts/build_gaea_c5.sh
@@ -9,7 +9,6 @@ module rm PrgEnv-intel
 module load PrgEnv-gnu
 module rm gcc
 module load gcc/12.2.0
-module load boost/1.79.0
 module load python/3.9
 
 # clone Pace and update submodules

--- a/examples/build_scripts/build_gaea_c5_gcc.sh
+++ b/examples/build_scripts/build_gaea_c5_gcc.sh
@@ -9,7 +9,6 @@ module rm PrgEnv-intel
 module load PrgEnv-gnu
 module rm gcc
 module load gcc/12.2.0
-module load boost/1.79.0
 module load python/3.11.7
 
 export CC=`which gcc`


### PR DESCRIPTION
**Description**

Newer GT4Py versions come with vendored-in boost headers. NDSL picked up this newer boost version and thus pace doesn't need boost in the install notes anymore.

For the record: The relevant GT4Py update in NDSL was done in https://github.com/NOAA-GFDL/NDSL/pull/150.

**How Has This Been Tested?**

By doing a self-review of the code changes.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
