### PR TITLE
Baroclinic Steady State Test Case

### DIFF
--- a/.jenkins/driver_configs/baroclinic_c192_54ranks.yaml
+++ b/.jenkins/driver_configs/baroclinic_c192_54ranks.yaml
@@ -8,7 +8,7 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 diagnostics_config:
   path: "output.zarr"
   names:

--- a/.jenkins/driver_configs/baroclinic_c192_6ranks.yaml
+++ b/.jenkins/driver_configs/baroclinic_c192_6ranks.yaml
@@ -8,7 +8,7 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 diagnostics_config:
   path: "output.zarr"
   names:
@@ -18,7 +18,7 @@ diagnostics_config:
 output_initial_state: true
 performance_config:
   collect_performance: true
-  experiment_name: c192_baroclinic
+  experiment_name: c192_baroclinic_instability
 nx_tile: 192
 nz: 79
 dt_atmos: 200

--- a/.jenkins/driver_configs/baroclinic_c48_6ranks_dycore_only.yaml
+++ b/.jenkins/driver_configs/baroclinic_c48_6ranks_dycore_only.yaml
@@ -11,7 +11,7 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinicc
+    case: baroclinic_instability
 performance_config:
   collect_performance: false
 nx_tile: 48

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -5,10 +5,12 @@ Currently, driver takes in a yaml config containing the following options. Examp
 Configuration options pertaining to GT4Py stencils such as backend and whether to rebuild stencils.
 
 ## initialization_type
-Driver initialization type can be either `baroclinic` or `serialbox`.
+Driver initialization type can be either `analytic`, `restart`, `fortran_restart`, `serialbox`, or `predefined`.
 
 ## initialization_config
-**`baroclinic`**:  no additional config needs to be specified.
+**`analytic`**:  `case` can optionally be set to `baroclinic_instability` (default) or `baroclinic_steady`. `start_time` can optionally be set to a datetime (default: 2000-1-1).
+
+[TODO] Update initialization_config parameters for other initialization types
 
 **`serialbox`**:  `path` to the test data directory and optionally `serialized_grid` to specify whether to create grid from serialized data or calculate them in Python. The directory should have the necessary serialized data and a fortran namelist which will be used to set options such as dycore_config and physics_config. Currently, the supported serialized dataset is the same as the test case in pace-physics. To obtain this data, run the following command at the top level:
 ```

--- a/examples/configs/analytic_test.yaml
+++ b/examples/configs/analytic_test.yaml
@@ -8,10 +8,10 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: true
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 comm_config:
   type: null_comm
   config:

--- a/examples/configs/baroclinic_c12.yaml
+++ b/examples/configs/baroclinic_c12.yaml
@@ -8,10 +8,10 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: true
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 nx_tile: 12
 nz: 79
 dt_atmos: 225

--- a/examples/configs/baroclinic_c12_comm_read.yaml
+++ b/examples/configs/baroclinic_c12_comm_read.yaml
@@ -8,10 +8,10 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: false
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 comm_config:
   type: read
   config:

--- a/examples/configs/baroclinic_c12_comm_write.yaml
+++ b/examples/configs/baroclinic_c12_comm_write.yaml
@@ -8,10 +8,10 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: false
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 comm_config:
   type: write
   config:

--- a/examples/configs/baroclinic_c12_dp.yaml
+++ b/examples/configs/baroclinic_c12_dp.yaml
@@ -15,10 +15,10 @@ grid_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: true
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 nx_tile: 12
 nz: 79
 dt_atmos: 225

--- a/examples/configs/baroclinic_c12_explicit_physics.yaml
+++ b/examples/configs/baroclinic_c12_explicit_physics.yaml
@@ -8,10 +8,10 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: true
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 nx_tile: 12
 nz: 79
 dt_atmos: 225

--- a/examples/configs/baroclinic_c12_null_comm.yaml
+++ b/examples/configs/baroclinic_c12_null_comm.yaml
@@ -8,10 +8,10 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: false
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 comm_config:
   type: null_comm
   config:

--- a/examples/configs/baroclinic_c12_orch_cpu.yaml
+++ b/examples/configs/baroclinic_c12_orch_cpu.yaml
@@ -8,7 +8,7 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: false
 nx_tile: 12

--- a/examples/configs/baroclinic_c12_write_restart.yaml
+++ b/examples/configs/baroclinic_c12_write_restart.yaml
@@ -8,10 +8,10 @@ stencil_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: false
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 nx_tile: 12
 nz: 79
 dt_atmos: 225

--- a/examples/configs/test_external_C12_1x1.yaml
+++ b/examples/configs/test_external_C12_1x1.yaml
@@ -14,10 +14,10 @@ grid_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: true
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 nx_tile: 12
 nz: 79
 dt_atmos: 225

--- a/examples/configs/test_external_C12_2x2.yaml
+++ b/examples/configs/test_external_C12_2x2.yaml
@@ -14,10 +14,10 @@ grid_config:
 initialization:
   type: analytic
   config:
-    case: baroclinic
+    case: baroclinic_instability
 performance_config:
   collect_performance: true
-  experiment_name: c12_baroclinic
+  experiment_name: c12_baroclinic_instability
 nx_tile: 12
 nz: 79
 dt_atmos: 225

--- a/pace/driver.py
+++ b/pace/driver.py
@@ -37,6 +37,7 @@ from pace.grid import GeneratedGridConfig, GridInitializerSelector
 from pace.initialization import InitializerSelector
 from pace.safety_checks import SafetyChecker
 from pace.state import DriverState
+from pyFV3.initialization.analytic_init import AnalyticCase
 from pyFV3 import DynamicalCore, DynamicalCoreConfig
 from pySHiELD import Physics, PhysicsConfig
 from pySHiELD.update import update_atmos_state
@@ -266,9 +267,6 @@ class DriverConfig:
         kwargs["comm_config"] = CreatesCommSelector.from_dict(
             kwargs.get("comm_config", {})
         )
-        kwargs["initialization"] = InitializerSelector.from_dict(
-            kwargs["initialization"]
-        )
         if "grid_config" in kwargs:
             kwargs["grid_config"] = GridInitializerSelector.from_dict(
                 kwargs["grid_config"]
@@ -279,6 +277,15 @@ class DriverConfig:
                 kwargs["dycore_config"].grid_type = grid_type
                 if grid_type > 3:
                     kwargs["dycore_config"].ntiles = 1
+
+        analytic_hooks = {}
+        if kwargs["initialization"]["type"] == "analytic":
+            kwargs["initialization"]["config"]["dycore_config"] = kwargs["dycore_config"]
+            analytic_hooks[AnalyticCase] = AnalyticCase
+        kwargs["initialization"] = InitializerSelector.from_dict(
+            kwargs["initialization"],
+            hooks=analytic_hooks,
+        )
 
         if (
             isinstance(kwargs["stencil_config"], dict)
@@ -322,6 +329,9 @@ class DriverConfig:
             config_dict["dycore_config"].pop(field, None)
             config_dict["physics_config"].pop(field, None)
         config_dict["initialization"]["type"] = "restart"
+        # Remove existing initialization config and repopulate
+        config_dict["initialization"].pop("config")
+        config_dict["initialization"]["config"] = {}
         config_dict["initialization"]["config"]["start_time"] = time
         config_dict["initialization"]["config"]["path"] = restart_path
         # convert physics package enum to str

--- a/pace/driver.py
+++ b/pace/driver.py
@@ -37,8 +37,8 @@ from pace.grid import GeneratedGridConfig, GridInitializerSelector
 from pace.initialization import InitializerSelector
 from pace.safety_checks import SafetyChecker
 from pace.state import DriverState
-from pyFV3.initialization.analytic_init import AnalyticCase
 from pyFV3 import DynamicalCore, DynamicalCoreConfig
+from pyFV3.initialization.analytic_init import AnalyticCase
 from pySHiELD import Physics, PhysicsConfig
 from pySHiELD.update import update_atmos_state
 
@@ -280,7 +280,9 @@ class DriverConfig:
 
         analytic_hooks = {}
         if kwargs["initialization"]["type"] == "analytic":
-            kwargs["initialization"]["config"]["dycore_config"] = kwargs["dycore_config"]
+            kwargs["initialization"]["config"]["dycore_config"] = kwargs[
+                "dycore_config"
+            ]
             analytic_hooks[AnalyticCase] = AnalyticCase
         kwargs["initialization"] = InitializerSelector.from_dict(
             kwargs["initialization"],

--- a/pace/initialization.py
+++ b/pace/initialization.py
@@ -22,7 +22,8 @@ from ndsl.stencils.testing import TranslateGrid, grid
 from ndsl.typing import Communicator
 from pace.registry import Registry
 from pace.state import DriverState, TendencyState, _restart_driver_state
-from pyFV3 import DycoreState
+from pyFV3.initialization.analytic_init import AnalyticCase
+from pyFV3 import DycoreState, DynamicalCoreConfig
 from pyFV3.testing import TranslateFVDynamics
 from pySHiELD import PHYSICS_PACKAGES, PhysicsState
 
@@ -91,8 +92,8 @@ class InitializerSelector(Initializer):
         )
 
     @classmethod
-    def from_dict(cls, config: dict):
-        instance = cls.registry.from_dict(config)
+    def from_dict(cls, config: dict, hooks={}):
+        instance = cls.registry.from_dict(config, hooks=hooks)
         return cls(config=instance, type=config["type"])
 
 
@@ -103,8 +104,10 @@ class AnalyticInit(Initializer):
     Configuration for analytic initialization.
     """
 
-    case: str = "baroclinic"
+    case: AnalyticCase = AnalyticCase.baroclinic_instability
     start_time: datetime = datetime(2000, 1, 1)
+    dycore_config: DynamicalCoreConfig = dataclasses.field(default_factory=DynamicalCoreConfig)
+
 
     def get_driver_state(
         self,
@@ -119,9 +122,10 @@ class AnalyticInit(Initializer):
             analytic_init_case=self.case,
             grid_data=grid_data,
             quantity_factory=quantity_factory,
-            adiabatic=False,
-            hydrostatic=False,
-            moist_phys=True,
+            adiabatic=self.dycore_config.adiabatic,
+            hydrostatic=self.dycore_config.hydrostatic,
+            moist_phys=self.dycore_config.moist_phys,
+            sw_dynamics=self.dycore_config.sw_dynamics,
             comm=communicator,
         )
         physics_state = PhysicsState.init_zeros(

--- a/pace/initialization.py
+++ b/pace/initialization.py
@@ -22,8 +22,8 @@ from ndsl.stencils.testing import TranslateGrid, grid
 from ndsl.typing import Communicator
 from pace.registry import Registry
 from pace.state import DriverState, TendencyState, _restart_driver_state
-from pyFV3.initialization.analytic_init import AnalyticCase
 from pyFV3 import DycoreState, DynamicalCoreConfig
+from pyFV3.initialization.analytic_init import AnalyticCase
 from pyFV3.testing import TranslateFVDynamics
 from pySHiELD import PHYSICS_PACKAGES, PhysicsState
 
@@ -106,8 +106,9 @@ class AnalyticInit(Initializer):
 
     case: AnalyticCase = AnalyticCase.baroclinic_instability
     start_time: datetime = datetime(2000, 1, 1)
-    dycore_config: DynamicalCoreConfig = dataclasses.field(default_factory=DynamicalCoreConfig)
-
+    dycore_config: DynamicalCoreConfig = dataclasses.field(
+        default_factory=DynamicalCoreConfig
+    )
 
     def get_driver_state(
         self,

--- a/pace/registry.py
+++ b/pace/registry.py
@@ -105,7 +105,7 @@ class Registry(Generic[T]):
 
         return register_func
 
-    def from_dict(self, config: dict) -> T:
+    def from_dict(self, config: dict, hooks={}) -> T:
         """
         Creates a registered type from the given config dict.
 
@@ -130,6 +130,7 @@ class Registry(Generic[T]):
             instance = dacite.from_dict(
                 data_class=self._types[type_name],
                 data=config["config"],
-                config=dacite.Config(strict=True),
+                config=dacite.Config(strict=True,
+                                     type_hooks=hooks),
             )
             return instance

--- a/pace/registry.py
+++ b/pace/registry.py
@@ -130,7 +130,6 @@ class Registry(Generic[T]):
             instance = dacite.from_dict(
                 data_class=self._types[type_name],
                 data=config["config"],
-                config=dacite.Config(strict=True,
-                                     type_hooks=hooks),
+                config=dacite.Config(strict=True, type_hooks=hooks),
             )
             return instance

--- a/tests/main/driver/test_analytic_init.py
+++ b/tests/main/driver/test_analytic_init.py
@@ -34,7 +34,10 @@ def test_analytic_init_config(tested_configs: List[Path]):
         # config and analytic case types for addition consistency checks.
         # Other initialization types don't require this.
         if driver_config.initialization.type == "analytic":
-            assert type(driver_config.initialization.config.dycore_config) == DynamicalCoreConfig
+            assert (
+                type(driver_config.initialization.config.dycore_config)
+                == DynamicalCoreConfig
+            )
             assert hasattr(driver_config.initialization.config, "case")
             assert type(driver_config.initialization.config.case) == AnalyticCase
         else:

--- a/tests/main/driver/test_analytic_init.py
+++ b/tests/main/driver/test_analytic_init.py
@@ -5,6 +5,8 @@ import pytest
 import yaml
 
 from pace import DriverConfig
+from pyFV3 import DynamicalCoreConfig
+from pyFV3.initialization.analytic_init import AnalyticCase
 from tests.paths import EXAMPLE_CONFIGS_DIR
 
 
@@ -13,6 +15,7 @@ from tests.paths import EXAMPLE_CONFIGS_DIR
 
 TESTED_CONFIGS: List[Path] = [
     EXAMPLE_CONFIGS_DIR / "analytic_test.yaml",
+    EXAMPLE_CONFIGS_DIR / "baroclinic_c48_6ranks_serialbox_test.yaml",
 ]
 
 
@@ -27,4 +30,12 @@ def test_analytic_init_config(tested_configs: List[Path]):
         with open(Path(__file__).parent / config_file, "r") as f:
             config = yaml.safe_load(f)
         driver_config = DriverConfig.from_dict(config)
-        assert driver_config.initialization.type == "analytic"
+        # Analytic initialization contains a copy of the dynamical core
+        # config and analytic case types for addition consistency checks.
+        # Other initialization types don't require this.
+        if driver_config.initialization.type == "analytic":
+            assert type(driver_config.initialization.config.dycore_config) == DynamicalCoreConfig
+            assert hasattr(driver_config.initialization.config, "case")
+            assert type(driver_config.initialization.config.case) == AnalyticCase
+        else:
+            assert not hasattr(driver_config.initialization, "dycore_config")

--- a/tests/main/driver/test_restart_serial.py
+++ b/tests/main/driver/test_restart_serial.py
@@ -71,7 +71,7 @@ def test_restart_save_to_disk():
         (damping_coefficients, driver_grid_data, grid_data,) = GeneratedGridConfig(
             eta_file=eta_file
         ).get_grid(quantity_factory, communicator)
-        init = AnalyticInit()
+        init = AnalyticInit(dycore_config=driver_config.dycore_config)
         driver_state = init.get_driver_state(
             quantity_factory=quantity_factory,
             communicator=communicator,

--- a/tests/main/fv3core/test_dycore_baroclinic.py
+++ b/tests/main/fv3core/test_dycore_baroclinic.py
@@ -1,5 +1,5 @@
-""" Unit tests for Jablonowski & Williamson Baroclinic test cases 
-Corresponds to Fortran test #12 (Steady State) and #13 (Perturbation) 
+""" Unit tests for Jablonowski & Williamson Baroclinic test cases
+Corresponds to Fortran test #12 (Steady State) and #13 (Perturbation)
 found in tools/test_cases.F90 of:
 
 https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git
@@ -7,7 +7,6 @@ https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git
 TODO This is a place holder class for more unit tests in the future.
 """
 
-import os
 from datetime import timedelta
 
 import pyFV3.initialization.analytic_init as ai
@@ -22,19 +21,15 @@ from ndsl import (
     StencilConfig,
     StencilFactory,
     SubtileGridSizer,
-    TilePartitioner,
     TileCommunicator,
+    TilePartitioner,
 )
+from ndsl.grid import DampingCoefficients, GridData, MetricTerms
 from ndsl.performance.timer import NullTimer
-from ndsl.grid import (
-    DampingCoefficients,
-    GridData,
-    MetricTerms,
-)
 from pyFV3 import DycoreState, DynamicalCore, DynamicalCoreConfig
 
 
-def setup_dycore_config(test_case=ai.AnalyticCase.baroclinic_instability) -> DynamicalCoreConfig:
+def setup_dycore_config() -> DynamicalCoreConfig:
     config = DynamicalCoreConfig(
         layout=(1, 1),
         npx=48,
@@ -50,10 +45,10 @@ def setup_dycore_config(test_case=ai.AnalyticCase.baroclinic_instability) -> Dyn
         d2_bg_k1=0.2,
         d2_bg_k2=0.1,
         d4_bg=0.15,
-        d_con=0.0,       # Default is 0 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
+        d_con=0.0,  # Default is 0 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
         d_ext=0.0,
         dddmp=0.5,
-        #delt_max=0.002,  # TODO: What is equiv in SHiELD_build?
+        # delt_max=0.002,  # TODO: What is equiv in SHiELD_build?
         do_sat_adj=True,
         do_vort_damp=True,
         fill=True,
@@ -64,14 +59,14 @@ def setup_dycore_config(test_case=ai.AnalyticCase.baroclinic_instability) -> Dyn
         hord_vt=6,
         hydrostatic=False,
         k_split=1,
-        ke_bg=0.0,       # Default is 0 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
+        ke_bg=0.0,  # Default is 0 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
         kord_mt=9,
         kord_tm=-9,
         kord_tr=9,
         kord_wz=9,
         n_split=1,
         nord=3,
-        p_fac=0.05,      # Default is 0.05 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
+        p_fac=0.05,  # Default is 0.05 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
         rf_fast=True,
         rf_cutoff=3000.0,
         tau=10.0,
@@ -84,14 +79,12 @@ def setup_dycore_config(test_case=ai.AnalyticCase.baroclinic_instability) -> Dyn
 
 
 def setup_dycore(
-    rank=0,
-    usesCubedSphereComm=True,
-    test_case=ai.AnalyticCase.baroclinic_instability
+    rank=0, usesCubedSphereComm=True, test_case=ai.AnalyticCase.baroclinic_instability
 ) -> DycoreState:
     """Sets up Dycore state for analytic initialization"""
 
     backend = "numpy"
-    config = setup_dycore_config(test_case=test_case)
+    config = setup_dycore_config()
     mpi_comm = NullComm(
         rank=rank, total_ranks=6 * config.layout[0] * config.layout[1], fill_value=0.0
     )
@@ -164,11 +157,9 @@ def setup_dycore(
 def test_baroclinic_steady_and_instability_are_different():
     """
     Simple test to check that the steady and instability tests produce
-    different results.   
+    different results.
     """
-    _, state_steady, _ = setup_dycore(
-        test_case=ai.AnalyticCase.baroclinic_steady
-    )
+    _, state_steady, _ = setup_dycore(test_case=ai.AnalyticCase.baroclinic_steady)
     _, state_instability, _ = setup_dycore(
         test_case=ai.AnalyticCase.baroclinic_instability
     )

--- a/tests/main/fv3core/test_dycore_baroclinic.py
+++ b/tests/main/fv3core/test_dycore_baroclinic.py
@@ -1,0 +1,547 @@
+""" Unit tests for Jablonowski & Williamson Baroclinic test cases 
+Corresponds to Fortran test #12 (Steady State) and #13 (Perturbation) 
+found in tools/test_cases.F90 of:
+
+https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git
+"""
+
+import os
+from datetime import timedelta
+from unittest import mock
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import xarray as xr
+from typing import Tuple
+
+
+import pyFV3.initialization.analytic_init as ai
+from ndsl import (
+    CompilationConfig,
+    CubedSphereCommunicator,
+    CubedSpherePartitioner,
+    DaceConfig,
+    GridIndexing,
+    NullComm,
+    QuantityFactory,
+    StencilConfig,
+    StencilFactory,
+    SubtileGridSizer,
+    TilePartitioner,
+    TileCommunicator,
+)
+from ndsl.grid import DampingCoefficients, GridData, MetricTerms
+from ndsl.performance.timer import NullTimer
+from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM
+from ndsl.grid import (
+    AngleGridData,
+    ContravariantGridData,
+    DampingCoefficients,
+    GridData,
+    HorizontalGridData,
+    MetricTerms,
+    VerticalGridData,
+)
+from ndsl.comm.partitioner import get_tile_index
+
+from pyFV3 import DycoreState, DynamicalCore, DynamicalCoreConfig
+from pace.grid import ExternalNetcdfGridConfig
+
+
+DIR = os.path.abspath(os.path.dirname(__file__))
+PACE_DIR = os.path.join(DIR, "..", "..", "..")
+BC_DIR = os.path.join(PACE_DIR, "tests", "main", "data", "baroclinic")
+
+
+@pytest.fixture()
+def setenv_pace32(monkeypatch: pytest.MonkeyPatch):
+    #TODO: doublecheck monkey patch fixture?
+    #Monkeypatching: https://docs.pytest.org/en/stable/how-to/monkeypatch.html
+    #Fixture example found here: https://stackoverflow.com/questions/77255758/how-can-i-mock-my-environment-variables-for-my-pytest
+    #https://github.com/pytest-dev/pytest/issues/4576
+    #https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch.dict
+    with mock.patch.dict(os.environ):
+        monkeypatch.setenv("PACE_FLOAT_PRECISION", "32")
+        yield # Restore the environment after 
+
+
+@pytest.fixture()
+def setenv_pace64(monkeypatch: pytest.MonkeyPatch):
+    with mock.patch.dict(os.environ):
+        monkeypatch.setenv("PACE_FLOAT_PRECISION", "64")
+        yield # Restore the environment after
+
+
+def setup_dycore_config(test_case=ai.Cases.baroclinic) -> DynamicalCoreConfig:
+    config = DynamicalCoreConfig(
+        layout=(1, 1),
+        npx=49,
+        npy=49,
+        npz=32,
+        ntiles=6,
+        nwat=6,
+        dt_atmos=225,
+        a_imp=1.0,
+        beta=0.0,
+        consv_te=False,  # not implemented, needs allreduce
+        d2_bg=0.0,
+        d2_bg_k1=0.2,
+        d2_bg_k2=0.1,
+        d4_bg=0.15,
+        d_con=0.0,       # Default is 0 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
+        d_ext=0.0,
+        dddmp=0.5,
+        #delt_max=0.002,  # TODO: What is equiv in SHiELD_build?
+        do_sat_adj=True,
+        do_vort_damp=True,
+        fill=True,
+        hord_dp=6,
+        hord_mt=6,
+        hord_tm=6,
+        hord_tr=8,
+        hord_vt=6,
+        hydrostatic=False,
+        k_split=1,
+        ke_bg=0.0,       # Default is 0 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
+        kord_mt=9,
+        kord_tm=-9,
+        kord_tr=9,
+        kord_wz=9,
+        n_split=1,
+        nord=3,
+        p_fac=0.05,      # Default is 0.05 in GFDL_atmos_cubed_sphere/model/fv_arrays.F90
+        rf_fast=True,
+        rf_cutoff=3000.0,
+        tau=10.0,
+        vtdm4=0.06,
+        z_tracer=True,
+        do_qa=True,
+        moist_phys=True,
+    )
+    return config
+
+
+def setup_external_grid_data_b(
+        quantity_factory: QuantityFactory,
+        communicator: CubedSphereCommunicator,
+        eta_file: str
+) -> Tuple[DampingCoefficients, GridData]:
+    """TODO: flesh this out"""
+    grid_file_path = os.path.join(BC_DIR, "grid_C48", "C48.BC.tile" )
+    grid_type=0
+    tile_num = (
+        get_tile_index(communicator.rank, communicator.partitioner.total_ranks)
+        + 1
+    )
+    tile_file = grid_file_path + str(tile_num) + ".nc"
+
+    ds = xr.open_dataset(tile_file)
+    lon = ds.x.values
+    lat = ds.y.values
+    npx = ds.nxp.values.size
+    npy = ds.nyp.values.size
+
+    subtile_slice_grid = communicator.partitioner.tile.subtile_slice(
+        rank=communicator.rank,
+        global_dims=[Y_INTERFACE_DIM, X_INTERFACE_DIM],
+        global_extent=(npy, npx),
+        overlap=True,
+    )
+
+    metric_terms = MetricTerms.from_external(
+        x=lon[subtile_slice_grid],
+        y=lat[subtile_slice_grid],
+        quantity_factory=quantity_factory,
+        communicator=communicator,
+        grid_type=0,
+        eta_file=eta_file,
+    )
+
+    horizontal_data = HorizontalGridData.new_from_metric_terms(metric_terms)
+    vertical_data = VerticalGridData.new_from_metric_terms(metric_terms)
+    contravariant_data = ContravariantGridData.new_from_metric_terms(metric_terms)
+    angle_data = AngleGridData.new_from_metric_terms(metric_terms)
+    grid_data = GridData(
+        horizontal_data=horizontal_data,
+        vertical_data=vertical_data,
+        contravariant_data=contravariant_data,
+        angle_data=angle_data,
+    )
+
+    damping_coefficients = DampingCoefficients.new_from_metric_terms(metric_terms)
+
+    return damping_coefficients, grid_data
+
+
+def setup_external_grid_data_a(
+        quantity_factory: QuantityFactory,
+        communicator: CubedSphereCommunicator,
+        eta_file: str
+) -> Tuple[DampingCoefficients, GridData]:
+    """TODO: flesh this out"""
+    grid_file_path = os.path.join(BC_DIR, "grid_C48", "C48.BC.tile" )
+    ext_grid_config = ExternalNetcdfGridConfig(
+        grid_type=0,
+        grid_file_path=grid_file_path,
+        eta_file=eta_file,
+    )
+    damping_coefficients, _, grid_data = ext_grid_config.get_grid(
+        quantity_factory=quantity_factory,
+        communicator=communicator,
+    ) 
+    return damping_coefficients, grid_data
+
+
+def setup_dycore(rank=0, usesCubedSphereComm=True, test_case=ai.Cases.baroclinic.value) -> DycoreState:
+    """Sets up Dycore state for analytic initialization"""
+    backend = "numpy"
+    config = setup_dycore_config(test_case=test_case)
+    mpi_comm = NullComm(
+        rank=rank, total_ranks=6 * config.layout[0] * config.layout[1], fill_value=0.0
+    )
+    partitioner = CubedSpherePartitioner(TilePartitioner(config.layout))
+
+    if usesCubedSphereComm:
+        communicator = CubedSphereCommunicator(mpi_comm, partitioner)
+    else:
+        communicator = TileCommunicator(mpi_comm, partitioner)
+
+    dace_config = DaceConfig(communicator=communicator, backend=backend)
+    stencil_config = StencilConfig(
+        compilation_config=CompilationConfig(
+            backend=backend, rebuild=False, validate_args=True
+        ),
+        dace_config=dace_config,
+    )
+    sizer = SubtileGridSizer.from_tile_params(
+        nx_tile=config.npx - 1,
+        ny_tile=config.npy - 1,
+        nz=config.npz,
+        n_halo=3,
+        extra_dim_lengths={},
+        layout=config.layout,
+        tile_partitioner=partitioner.tile,
+        tile_rank=communicator.tile.rank,
+    )
+    grid_indexing = GridIndexing.from_sizer_and_communicator(
+        sizer=sizer, comm=communicator
+    )
+    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+    eta_file = "tests/main/input/eta32.nc" # TODO: where to document file creation for developers?
+    metric_terms = MetricTerms(
+        quantity_factory=quantity_factory,
+        communicator=communicator,
+        eta_file=eta_file,
+    )
+    grid_data = GridData.new_from_metric_terms(metric_terms)
+    damping_coefficients = DampingCoefficients.new_from_metric_terms(metric_terms)
+
+    #damping_coefficients2, grid_data2 = setup_external_grid_data_a(
+    #    quantity_factory=quantity_factory,
+    #    communicator=communicator,
+    #    eta_file=eta_file,
+    #)
+
+    #damping_coefficients3, grid_data3 = setup_external_grid_data_b(
+    #    quantity_factory=quantity_factory,
+    #    communicator=communicator,
+    #    eta_file=eta_file,
+    #)
+
+    state = ai.init_analytic_state(
+        analytic_init_case=test_case,
+        grid_data=grid_data,
+        quantity_factory=quantity_factory,
+        config=config,
+        comm=communicator,
+    )
+    stencil_factory = StencilFactory(
+        config=stencil_config,
+        grid_indexing=grid_indexing,
+    )
+
+    dycore = DynamicalCore(
+        comm=communicator,
+        grid_data=grid_data,
+        stencil_factory=stencil_factory,
+        quantity_factory=quantity_factory,
+        damping_coefficients=damping_coefficients,
+        config=config,
+        timestep=timedelta(seconds=config.dt_atmos),
+        phis=state.phis,
+        state=state,
+    )
+    return dycore, state, NullTimer()
+
+def plot_2d_diff(testname, rank, attribute, ds_values, state_values, plot_dir="."):
+    os.makedirs(plot_dir, exist_ok=True)
+    diff = ds_values - state_values
+    plt.title(f"diff: Fortran - Pace for '{attribute}'")
+    plt.imshow(diff, cmap="viridis")
+    plt.colorbar()
+    plt.savefig(
+        os.path.join(
+            plot_dir,
+            f"test_{testname}_diff_r{rank}_{attribute}.png"
+        )
+    )
+    plt.clf()
+
+    # Normalize the differences. Take the regular diff when ds_value is 0
+    norm_diff = np.where(
+        ds_values != 0, 
+        np.absolute((ds_values - state_values) / ds_values), 
+        np.absolute(ds_values - state_values)
+    )
+    plt.title(f"norm_diff: abs(Fortran - Pace / Fortran) for '{attribute}'")
+    plt.imshow(norm_diff, cmap="viridis")
+    plt.colorbar()
+    plt.savefig(
+        os.path.join(
+            plot_dir,
+            f"test_{testname}_norm_diff_r{rank}_{attribute}.png"
+        )
+    )
+    plt.clf()
+
+
+def plot_2d(desc, rank, attribute, data, plot_dir="."):
+    os.makedirs(plot_dir, exist_ok=True)
+    plt.title(f"{desc} - rank:{rank}, '{attribute}'")
+    plt.imshow(data, cmap="viridis")
+    plt.colorbar()
+    plt.savefig(
+        os.path.join(
+            plot_dir,
+            f"test_{desc}_r{rank}_{attribute}.png"
+        )
+    )
+    plt.clf()
+
+
+def check_init(data_dir,
+               attributes,
+               max_eps_errors,
+               gen_plots=False,
+               plot_dir=".",
+               step=False,
+               test_case=ai.Cases.baroclinic,
+               desc="test13_64",
+               rank_range=range(0,6)):
+    """TODO: doc"""
+    precision = "64"
+    if 'PACE_FLOAT_PRECISION' in os.environ:
+        precision = os.getenv("PACE_FLOAT_PRECISION", "SHOULD_NOT_BE_USED")
+    print(f"precision: {precision}")
+    # jk TODO: log precision instead?
+    
+    for rank in rank_range:
+        dycore, state, timer = setup_dycore(rank=rank, test_case=test_case)
+
+        fortran_rank = rank + 1
+        if step: 
+            dycore.step_dynamics(state, timer)
+        core_ds = xr.open_dataset(
+            os.path.join(data_dir, f"fv_core.res.tile{fortran_rank}.nc")
+        )
+        for attribute, max_eps_error in zip(attributes, max_eps_errors):
+            print(f"rank {rank}, attribute {attribute}")
+            # Dycore values/dimensions
+            state_values = getattr(state, attribute.lower()).view[:]
+            state_ndims = len(getattr(state, attribute.lower()).dims)
+
+            # Dataset values for 3D/2D Attributes at time zero
+            if state_ndims == 2:  # 2D
+                core_ds_values = core_ds[attribute].values[0, :].transpose(1, 0)
+                core_ds_values_2d, state_values_2d = core_ds_values, state_values
+            elif state_ndims == 3:  # 3D
+                core_ds_values = core_ds[attribute].values[0, :].transpose(2, 1, 0)
+                core_ds_values_2d, state_values_2d = (
+                    core_ds_values[:, :, 0],
+                    state_values[:, :, 0],
+                )
+            else:
+                assert False, f"Unexpected number of dims in DycoreState {attribute}"
+
+            # TODO: Remove plotting eventually
+            if gen_plots:
+                step_prefix = "step1_" if step else "t0_"
+                plot_2d(f"{step_prefix}pace.{desc}", rank, attribute, state_values_2d, plot_dir=plot_dir)
+                plot_2d(f"{step_prefix}ds.{desc}", rank, attribute, core_ds_values_2d, plot_dir=plot_dir)
+                plot_2d_diff(f"{step_prefix}{desc}", rank, attribute, core_ds_values_2d, state_values_2d, plot_dir=plot_dir)
+
+            norm_diff = np.where(
+                core_ds_values != 0, 
+                np.absolute((core_ds_values - state_values) / core_ds_values), 
+                np.absolute(core_ds_values - state_values)
+            )
+            max_error_norm_diff = np.max(norm_diff) # TODO: Use this when values don't blow up...?
+            max_error_diff = np.max(np.abs(core_ds_values - state_values))
+            assert max_error_diff < max_eps_error
+
+    # NOTE: The original test_cases.F90 initialized tracers for cl and cl2,
+    #       but we do not initialize or check for them in this test.
+
+
+
+# TODO: Why doesn't this work instead of setenv_pace64?
+#@mock.patch.dict("os.environ", {"PACE_FLOAT_PRECISION", "64"})
+#def test_rossby_init64():
+def test_baroclinic_init64(setenv_pace64: None):
+    """Tests case #13 (Perturbation) initialization for 64bit precision
+    Compare initialized DycoreState values with ground truth net-cdf files.
+
+    Ground truth RESTART files were generated using the following script: 
+    TODO (where to put the script?)
+    Using SHiELD_build 8309e1151812f72dda41142a16da0eb1f2bc4f8a (5/22/2025)
+    """
+    desc = "test13_64_debug_rs"
+    data_dir = os.path.join(BC_DIR, desc)
+    attributes = ["phis", "delp", "u", "v"] # TODO: more attributes
+    max_eps_errors = [5e-12, 1e-14, 2e-12, 2e-12]
+    check_init(data_dir, attributes, max_eps_errors, test_case=ai.Cases.baroclinic.value, gen_plots=True, desc=desc, plot_dir=desc)
+
+
+def test_baroclinic_init32(setenv_pace32: None):
+    """Tests case #13 (Perturbation) initialization for 32bit precision
+    Compare initialized DycoreState values with ground truth net-cdf files.
+    """
+    desc = "test13_32_debug_rs"
+    data_dir = os.path.join(BC_DIR, desc)
+    attributes = ["phis", "delp", "u", "v"] # TODO: more attributes
+    max_eps_errors = [8e-4, 4e-3, 8e-6, 8e-6]
+    check_init(data_dir, attributes, max_eps_errors, test_case=ai.Cases.baroclinic.value, gen_plots=True, desc=desc, plot_dir=desc)
+
+
+def test_baroclinic_12_init64(setenv_pace64: None):
+    """Tests case #12 (Steady State) initialization for 64bit precision
+    Compare initialized DycoreState values with ground truth net-cdf files.
+    """
+    desc = "test12_64_debug_rs"
+    data_dir = os.path.join(BC_DIR, desc)
+    attributes = ["phis", "delp", "u", "v"] # TODO: more attributes
+    max_eps_errors = [5e-12, 1e-14, 2e-12, 2e-12]
+    check_init(data_dir, attributes, max_eps_errors, test_case=ai.Cases.baroclinic_ss.value, gen_plots=True, desc=desc, plot_dir=desc)
+
+
+def test_baroclinic_12_init32(setenv_pace32: None):
+    """Tests case #12 (Steady State) initialization for 32bit precision
+    Compare initialized DycoreState values with ground truth net-cdf files.
+    """
+    #data_dir = os.path.join(BC_DIR, "C96.solo.BCmoist.pace_12_32") # TODO: REMOVE
+    desc = "test12_32_debug_rs"
+    data_dir = os.path.join(BC_DIR, desc)
+    attributes = ["phis", "delp", "u", "v"] # TODO: more attributes
+    max_eps_errors = [8e-4, 4e-3, 8e-6, 8e-6]
+    check_init(data_dir, attributes, max_eps_errors, test_case=ai.Cases.baroclinic_ss.value, gen_plots=True, desc=desc, plot_dir=desc)
+
+
+def test_tmp_grid_checks(setenv_pace64: None):
+    """
+    Compare SHiELD restart and Pace output grid net-cdf files.
+    """
+    # Load Pace grid data - x, y (requires conversion from radians to ??? TODO)
+    pace_out_dir = "/home/Janice.Kim/pace/baroclinic_comparison_20250613_a/output.netcfg.baroclinic_c48_test13"
+    pace_lat_path = os.path.join(pace_out_dir, "constants_lat.nc")
+    pace_lat_ds = xr.open_dataset(pace_lat_path)
+
+    # Load SHiELD grid data - from Fre NC Tools make_hgrid
+    backend = "numpy"
+    config = setup_dycore_config(test_case="baroclinic_ss")
+    mpi_comm = NullComm(
+        rank=0, total_ranks=6 * config.layout[0] * config.layout[1], fill_value=0.0
+    )
+    partitioner = CubedSpherePartitioner(TilePartitioner(config.layout))
+
+    communicator = CubedSphereCommunicator(mpi_comm, partitioner)
+
+    sizer = SubtileGridSizer.from_tile_params(
+        nx_tile=config.npx - 1,
+        ny_tile=config.npy - 1,
+        nz=config.npz,
+        n_halo=3,
+        extra_dim_lengths={},
+        layout=config.layout,
+        tile_partitioner=partitioner.tile,
+        tile_rank=communicator.tile.rank,
+    )
+    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+    eta_file = "tests/main/input/eta32.nc"
+
+    _, grid_data = setup_external_grid_data_a(
+        quantity_factory=quantity_factory,
+        communicator=communicator,
+        eta_file=eta_file,
+    )
+    shield_lat = grid_data.lat.field
+
+    # Compare
+    # shield_lat[:] should be == pace_lat_ds.lat[0].data[:]
+    # Sigh... but what does this prove? They should be the same.
+    # I think I need to go the other way... convert pace to cartesian and see if it matches
+    # the FRE NC tools generated tile files. (?) TODO
+
+    pass
+
+
+# TODO: jk delete this before merge; temp test
+def test_rusty(setenv_pace64: None): 
+    shield_path = '/home/Rusty.Benson/SHiELD/SHiELD_build/CI/BATCH-CI/C48.solo.BCmoist/RESTART/fv_core.res.tile1.nc'
+    pace_path = '/home/Rusty.Benson/PACE/pace/RESTART/restart_dycore_state_0.nc'
+
+    attribute = 'u'
+
+    shield_ds = xr.open_dataset(shield_path)
+    time = 0
+    z = 0
+    shield_xy0 = shield_ds['u'][time][z].T
+
+    num_halos = 3
+    pace_ds = xr.open_dataset(pace_path)
+    # TODO: I know that the x isn't x_interface, I should be able to figure that out without manually compensating.
+    pace_xy0 = pace_ds['u'][num_halos:-(num_halos+1),num_halos:-num_halos,z]
+
+    rank = 0
+    plot_dir = 'compare_rusty'
+    plot_2d(f"shield", rank, attribute, shield_xy0, plot_dir=plot_dir)
+    plot_2d(f"pace", rank, attribute, pace_xy0, plot_dir=plot_dir)
+
+
+    os.makedirs(plot_dir, exist_ok=True)
+    diff = shield_xy0.data - pace_xy0.data
+    plt.title(f"diff: SHiELD - Pace for '{attribute}'")
+    plt.imshow(diff, cmap="viridis")
+    plt.colorbar()
+    plt.savefig(
+        os.path.join(
+            plot_dir,
+            f"test_diff_r{rank}_{attribute}.png"
+        )
+    )
+    plt.clf()
+
+    #not_zero_mask = diff[diff != 0] # TODO: jk zero comparison okay?
+    #norm_diff = diff.copy()
+    #norm_diff[not_zero_mask] = np.absolute((ds_values - state_values) / ds_values)
+    norm_diff = np.absolute((shield_xy0.data - pace_xy0.data) / shield_xy0.data)
+    plt.title(f"norm_diff: abs(Fortran - Pace / Fortran) for '{attribute}'")
+    plt.imshow(norm_diff, cmap="viridis")
+    plt.colorbar()
+    plt.savefig(
+        os.path.join(
+            plot_dir,
+            f"test_norm_diff_r{rank}_{attribute}.png"
+        )
+    )
+    plt.clf()
+
+    max_eps_error = 1e-12
+
+    shield_minus_pace = shield_xy0.data - pace_xy0.data
+    max_error_diff = np.max(
+        np.absolute((shield_minus_pace) / shield_xy0.data)
+    )
+    if np.isnan(max_error_diff): # e.g., from zero division
+        max_error_diff = np.max(np.absolute(shield_minus_pace))
+
+    assert max_error_diff < max_eps_error

--- a/tests/main/fv3core/test_dycore_baroclinic.py
+++ b/tests/main/fv3core/test_dycore_baroclinic.py
@@ -3,17 +3,12 @@ Corresponds to Fortran test #12 (Steady State) and #13 (Perturbation)
 found in tools/test_cases.F90 of:
 
 https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git
+
+TODO This is a place holder class for more unit tests in the future.
 """
 
 import os
 from datetime import timedelta
-from unittest import mock
-import matplotlib.pyplot as plt
-import numpy as np
-import pytest
-import xarray as xr
-from typing import Tuple
-
 
 import pyFV3.initialization.analytic_init as ai
 from ndsl import (
@@ -30,54 +25,21 @@ from ndsl import (
     TilePartitioner,
     TileCommunicator,
 )
-from ndsl.grid import DampingCoefficients, GridData, MetricTerms
 from ndsl.performance.timer import NullTimer
-from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM
 from ndsl.grid import (
-    AngleGridData,
-    ContravariantGridData,
     DampingCoefficients,
     GridData,
-    HorizontalGridData,
     MetricTerms,
-    VerticalGridData,
 )
-from ndsl.comm.partitioner import get_tile_index
-
 from pyFV3 import DycoreState, DynamicalCore, DynamicalCoreConfig
-from pace.grid import ExternalNetcdfGridConfig
 
 
-DIR = os.path.abspath(os.path.dirname(__file__))
-PACE_DIR = os.path.join(DIR, "..", "..", "..")
-BC_DIR = os.path.join(PACE_DIR, "tests", "main", "data", "baroclinic")
-
-
-@pytest.fixture()
-def setenv_pace32(monkeypatch: pytest.MonkeyPatch):
-    #TODO: doublecheck monkey patch fixture?
-    #Monkeypatching: https://docs.pytest.org/en/stable/how-to/monkeypatch.html
-    #Fixture example found here: https://stackoverflow.com/questions/77255758/how-can-i-mock-my-environment-variables-for-my-pytest
-    #https://github.com/pytest-dev/pytest/issues/4576
-    #https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch.dict
-    with mock.patch.dict(os.environ):
-        monkeypatch.setenv("PACE_FLOAT_PRECISION", "32")
-        yield # Restore the environment after 
-
-
-@pytest.fixture()
-def setenv_pace64(monkeypatch: pytest.MonkeyPatch):
-    with mock.patch.dict(os.environ):
-        monkeypatch.setenv("PACE_FLOAT_PRECISION", "64")
-        yield # Restore the environment after
-
-
-def setup_dycore_config(test_case=ai.Cases.baroclinic) -> DynamicalCoreConfig:
+def setup_dycore_config(test_case=ai.AnalyticCase.baroclinic_instability) -> DynamicalCoreConfig:
     config = DynamicalCoreConfig(
         layout=(1, 1),
-        npx=49,
-        npy=49,
-        npz=32,
+        npx=48,
+        npy=48,
+        npz=79,
         ntiles=6,
         nwat=6,
         dt_atmos=225,
@@ -121,79 +83,13 @@ def setup_dycore_config(test_case=ai.Cases.baroclinic) -> DynamicalCoreConfig:
     return config
 
 
-def setup_external_grid_data_b(
-        quantity_factory: QuantityFactory,
-        communicator: CubedSphereCommunicator,
-        eta_file: str
-) -> Tuple[DampingCoefficients, GridData]:
-    """TODO: flesh this out"""
-    grid_file_path = os.path.join(BC_DIR, "grid_C48", "C48.BC.tile" )
-    grid_type=0
-    tile_num = (
-        get_tile_index(communicator.rank, communicator.partitioner.total_ranks)
-        + 1
-    )
-    tile_file = grid_file_path + str(tile_num) + ".nc"
-
-    ds = xr.open_dataset(tile_file)
-    lon = ds.x.values
-    lat = ds.y.values
-    npx = ds.nxp.values.size
-    npy = ds.nyp.values.size
-
-    subtile_slice_grid = communicator.partitioner.tile.subtile_slice(
-        rank=communicator.rank,
-        global_dims=[Y_INTERFACE_DIM, X_INTERFACE_DIM],
-        global_extent=(npy, npx),
-        overlap=True,
-    )
-
-    metric_terms = MetricTerms.from_external(
-        x=lon[subtile_slice_grid],
-        y=lat[subtile_slice_grid],
-        quantity_factory=quantity_factory,
-        communicator=communicator,
-        grid_type=0,
-        eta_file=eta_file,
-    )
-
-    horizontal_data = HorizontalGridData.new_from_metric_terms(metric_terms)
-    vertical_data = VerticalGridData.new_from_metric_terms(metric_terms)
-    contravariant_data = ContravariantGridData.new_from_metric_terms(metric_terms)
-    angle_data = AngleGridData.new_from_metric_terms(metric_terms)
-    grid_data = GridData(
-        horizontal_data=horizontal_data,
-        vertical_data=vertical_data,
-        contravariant_data=contravariant_data,
-        angle_data=angle_data,
-    )
-
-    damping_coefficients = DampingCoefficients.new_from_metric_terms(metric_terms)
-
-    return damping_coefficients, grid_data
-
-
-def setup_external_grid_data_a(
-        quantity_factory: QuantityFactory,
-        communicator: CubedSphereCommunicator,
-        eta_file: str
-) -> Tuple[DampingCoefficients, GridData]:
-    """TODO: flesh this out"""
-    grid_file_path = os.path.join(BC_DIR, "grid_C48", "C48.BC.tile" )
-    ext_grid_config = ExternalNetcdfGridConfig(
-        grid_type=0,
-        grid_file_path=grid_file_path,
-        eta_file=eta_file,
-    )
-    damping_coefficients, _, grid_data = ext_grid_config.get_grid(
-        quantity_factory=quantity_factory,
-        communicator=communicator,
-    ) 
-    return damping_coefficients, grid_data
-
-
-def setup_dycore(rank=0, usesCubedSphereComm=True, test_case=ai.Cases.baroclinic.value) -> DycoreState:
+def setup_dycore(
+    rank=0,
+    usesCubedSphereComm=True,
+    test_case=ai.AnalyticCase.baroclinic_instability
+) -> DycoreState:
     """Sets up Dycore state for analytic initialization"""
+
     backend = "numpy"
     config = setup_dycore_config(test_case=test_case)
     mpi_comm = NullComm(
@@ -227,7 +123,7 @@ def setup_dycore(rank=0, usesCubedSphereComm=True, test_case=ai.Cases.baroclinic
         sizer=sizer, comm=communicator
     )
     quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
-    eta_file = "tests/main/input/eta32.nc" # TODO: where to document file creation for developers?
+    eta_file = "tests/main/input/eta79.nc"
     metric_terms = MetricTerms(
         quantity_factory=quantity_factory,
         communicator=communicator,
@@ -236,23 +132,14 @@ def setup_dycore(rank=0, usesCubedSphereComm=True, test_case=ai.Cases.baroclinic
     grid_data = GridData.new_from_metric_terms(metric_terms)
     damping_coefficients = DampingCoefficients.new_from_metric_terms(metric_terms)
 
-    #damping_coefficients2, grid_data2 = setup_external_grid_data_a(
-    #    quantity_factory=quantity_factory,
-    #    communicator=communicator,
-    #    eta_file=eta_file,
-    #)
-
-    #damping_coefficients3, grid_data3 = setup_external_grid_data_b(
-    #    quantity_factory=quantity_factory,
-    #    communicator=communicator,
-    #    eta_file=eta_file,
-    #)
-
     state = ai.init_analytic_state(
         analytic_init_case=test_case,
         grid_data=grid_data,
         quantity_factory=quantity_factory,
-        config=config,
+        adiabatic=config.adiabatic,
+        hydrostatic=config.hydrostatic,
+        moist_phys=config.moist_phys,
+        sw_dynamics=config.sw_dynamics,
         comm=communicator,
     )
     stencil_factory = StencilFactory(
@@ -273,275 +160,16 @@ def setup_dycore(rank=0, usesCubedSphereComm=True, test_case=ai.Cases.baroclinic
     )
     return dycore, state, NullTimer()
 
-def plot_2d_diff(testname, rank, attribute, ds_values, state_values, plot_dir="."):
-    os.makedirs(plot_dir, exist_ok=True)
-    diff = ds_values - state_values
-    plt.title(f"diff: Fortran - Pace for '{attribute}'")
-    plt.imshow(diff, cmap="viridis")
-    plt.colorbar()
-    plt.savefig(
-        os.path.join(
-            plot_dir,
-            f"test_{testname}_diff_r{rank}_{attribute}.png"
-        )
-    )
-    plt.clf()
 
-    # Normalize the differences. Take the regular diff when ds_value is 0
-    norm_diff = np.where(
-        ds_values != 0, 
-        np.absolute((ds_values - state_values) / ds_values), 
-        np.absolute(ds_values - state_values)
-    )
-    plt.title(f"norm_diff: abs(Fortran - Pace / Fortran) for '{attribute}'")
-    plt.imshow(norm_diff, cmap="viridis")
-    plt.colorbar()
-    plt.savefig(
-        os.path.join(
-            plot_dir,
-            f"test_{testname}_norm_diff_r{rank}_{attribute}.png"
-        )
-    )
-    plt.clf()
-
-
-def plot_2d(desc, rank, attribute, data, plot_dir="."):
-    os.makedirs(plot_dir, exist_ok=True)
-    plt.title(f"{desc} - rank:{rank}, '{attribute}'")
-    plt.imshow(data, cmap="viridis")
-    plt.colorbar()
-    plt.savefig(
-        os.path.join(
-            plot_dir,
-            f"test_{desc}_r{rank}_{attribute}.png"
-        )
-    )
-    plt.clf()
-
-
-def check_init(data_dir,
-               attributes,
-               max_eps_errors,
-               gen_plots=False,
-               plot_dir=".",
-               step=False,
-               test_case=ai.Cases.baroclinic,
-               desc="test13_64",
-               rank_range=range(0,6)):
-    """TODO: doc"""
-    precision = "64"
-    if 'PACE_FLOAT_PRECISION' in os.environ:
-        precision = os.getenv("PACE_FLOAT_PRECISION", "SHOULD_NOT_BE_USED")
-    print(f"precision: {precision}")
-    # jk TODO: log precision instead?
-    
-    for rank in rank_range:
-        dycore, state, timer = setup_dycore(rank=rank, test_case=test_case)
-
-        fortran_rank = rank + 1
-        if step: 
-            dycore.step_dynamics(state, timer)
-        core_ds = xr.open_dataset(
-            os.path.join(data_dir, f"fv_core.res.tile{fortran_rank}.nc")
-        )
-        for attribute, max_eps_error in zip(attributes, max_eps_errors):
-            print(f"rank {rank}, attribute {attribute}")
-            # Dycore values/dimensions
-            state_values = getattr(state, attribute.lower()).view[:]
-            state_ndims = len(getattr(state, attribute.lower()).dims)
-
-            # Dataset values for 3D/2D Attributes at time zero
-            if state_ndims == 2:  # 2D
-                core_ds_values = core_ds[attribute].values[0, :].transpose(1, 0)
-                core_ds_values_2d, state_values_2d = core_ds_values, state_values
-            elif state_ndims == 3:  # 3D
-                core_ds_values = core_ds[attribute].values[0, :].transpose(2, 1, 0)
-                core_ds_values_2d, state_values_2d = (
-                    core_ds_values[:, :, 0],
-                    state_values[:, :, 0],
-                )
-            else:
-                assert False, f"Unexpected number of dims in DycoreState {attribute}"
-
-            # TODO: Remove plotting eventually
-            if gen_plots:
-                step_prefix = "step1_" if step else "t0_"
-                plot_2d(f"{step_prefix}pace.{desc}", rank, attribute, state_values_2d, plot_dir=plot_dir)
-                plot_2d(f"{step_prefix}ds.{desc}", rank, attribute, core_ds_values_2d, plot_dir=plot_dir)
-                plot_2d_diff(f"{step_prefix}{desc}", rank, attribute, core_ds_values_2d, state_values_2d, plot_dir=plot_dir)
-
-            norm_diff = np.where(
-                core_ds_values != 0, 
-                np.absolute((core_ds_values - state_values) / core_ds_values), 
-                np.absolute(core_ds_values - state_values)
-            )
-            max_error_norm_diff = np.max(norm_diff) # TODO: Use this when values don't blow up...?
-            max_error_diff = np.max(np.abs(core_ds_values - state_values))
-            assert max_error_diff < max_eps_error
-
-    # NOTE: The original test_cases.F90 initialized tracers for cl and cl2,
-    #       but we do not initialize or check for them in this test.
-
-
-
-# TODO: Why doesn't this work instead of setenv_pace64?
-#@mock.patch.dict("os.environ", {"PACE_FLOAT_PRECISION", "64"})
-#def test_rossby_init64():
-def test_baroclinic_init64(setenv_pace64: None):
-    """Tests case #13 (Perturbation) initialization for 64bit precision
-    Compare initialized DycoreState values with ground truth net-cdf files.
-
-    Ground truth RESTART files were generated using the following script: 
-    TODO (where to put the script?)
-    Using SHiELD_build 8309e1151812f72dda41142a16da0eb1f2bc4f8a (5/22/2025)
+def test_baroclinic_steady_and_instability_are_different():
     """
-    desc = "test13_64_debug_rs"
-    data_dir = os.path.join(BC_DIR, desc)
-    attributes = ["phis", "delp", "u", "v"] # TODO: more attributes
-    max_eps_errors = [5e-12, 1e-14, 2e-12, 2e-12]
-    check_init(data_dir, attributes, max_eps_errors, test_case=ai.Cases.baroclinic.value, gen_plots=True, desc=desc, plot_dir=desc)
-
-
-def test_baroclinic_init32(setenv_pace32: None):
-    """Tests case #13 (Perturbation) initialization for 32bit precision
-    Compare initialized DycoreState values with ground truth net-cdf files.
+    Simple test to check that the steady and instability tests produce
+    different results.   
     """
-    desc = "test13_32_debug_rs"
-    data_dir = os.path.join(BC_DIR, desc)
-    attributes = ["phis", "delp", "u", "v"] # TODO: more attributes
-    max_eps_errors = [8e-4, 4e-3, 8e-6, 8e-6]
-    check_init(data_dir, attributes, max_eps_errors, test_case=ai.Cases.baroclinic.value, gen_plots=True, desc=desc, plot_dir=desc)
-
-
-def test_baroclinic_12_init64(setenv_pace64: None):
-    """Tests case #12 (Steady State) initialization for 64bit precision
-    Compare initialized DycoreState values with ground truth net-cdf files.
-    """
-    desc = "test12_64_debug_rs"
-    data_dir = os.path.join(BC_DIR, desc)
-    attributes = ["phis", "delp", "u", "v"] # TODO: more attributes
-    max_eps_errors = [5e-12, 1e-14, 2e-12, 2e-12]
-    check_init(data_dir, attributes, max_eps_errors, test_case=ai.Cases.baroclinic_ss.value, gen_plots=True, desc=desc, plot_dir=desc)
-
-
-def test_baroclinic_12_init32(setenv_pace32: None):
-    """Tests case #12 (Steady State) initialization for 32bit precision
-    Compare initialized DycoreState values with ground truth net-cdf files.
-    """
-    #data_dir = os.path.join(BC_DIR, "C96.solo.BCmoist.pace_12_32") # TODO: REMOVE
-    desc = "test12_32_debug_rs"
-    data_dir = os.path.join(BC_DIR, desc)
-    attributes = ["phis", "delp", "u", "v"] # TODO: more attributes
-    max_eps_errors = [8e-4, 4e-3, 8e-6, 8e-6]
-    check_init(data_dir, attributes, max_eps_errors, test_case=ai.Cases.baroclinic_ss.value, gen_plots=True, desc=desc, plot_dir=desc)
-
-
-def test_tmp_grid_checks(setenv_pace64: None):
-    """
-    Compare SHiELD restart and Pace output grid net-cdf files.
-    """
-    # Load Pace grid data - x, y (requires conversion from radians to ??? TODO)
-    pace_out_dir = "/home/Janice.Kim/pace/baroclinic_comparison_20250613_a/output.netcfg.baroclinic_c48_test13"
-    pace_lat_path = os.path.join(pace_out_dir, "constants_lat.nc")
-    pace_lat_ds = xr.open_dataset(pace_lat_path)
-
-    # Load SHiELD grid data - from Fre NC Tools make_hgrid
-    backend = "numpy"
-    config = setup_dycore_config(test_case="baroclinic_ss")
-    mpi_comm = NullComm(
-        rank=0, total_ranks=6 * config.layout[0] * config.layout[1], fill_value=0.0
+    _, state_steady, _ = setup_dycore(
+        test_case=ai.AnalyticCase.baroclinic_steady
     )
-    partitioner = CubedSpherePartitioner(TilePartitioner(config.layout))
-
-    communicator = CubedSphereCommunicator(mpi_comm, partitioner)
-
-    sizer = SubtileGridSizer.from_tile_params(
-        nx_tile=config.npx - 1,
-        ny_tile=config.npy - 1,
-        nz=config.npz,
-        n_halo=3,
-        extra_dim_lengths={},
-        layout=config.layout,
-        tile_partitioner=partitioner.tile,
-        tile_rank=communicator.tile.rank,
+    _, state_instability, _ = setup_dycore(
+        test_case=ai.AnalyticCase.baroclinic_instability
     )
-    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
-    eta_file = "tests/main/input/eta32.nc"
-
-    _, grid_data = setup_external_grid_data_a(
-        quantity_factory=quantity_factory,
-        communicator=communicator,
-        eta_file=eta_file,
-    )
-    shield_lat = grid_data.lat.field
-
-    # Compare
-    # shield_lat[:] should be == pace_lat_ds.lat[0].data[:]
-    # Sigh... but what does this prove? They should be the same.
-    # I think I need to go the other way... convert pace to cartesian and see if it matches
-    # the FRE NC tools generated tile files. (?) TODO
-
-    pass
-
-
-# TODO: jk delete this before merge; temp test
-def test_rusty(setenv_pace64: None): 
-    shield_path = '/home/Rusty.Benson/SHiELD/SHiELD_build/CI/BATCH-CI/C48.solo.BCmoist/RESTART/fv_core.res.tile1.nc'
-    pace_path = '/home/Rusty.Benson/PACE/pace/RESTART/restart_dycore_state_0.nc'
-
-    attribute = 'u'
-
-    shield_ds = xr.open_dataset(shield_path)
-    time = 0
-    z = 0
-    shield_xy0 = shield_ds['u'][time][z].T
-
-    num_halos = 3
-    pace_ds = xr.open_dataset(pace_path)
-    # TODO: I know that the x isn't x_interface, I should be able to figure that out without manually compensating.
-    pace_xy0 = pace_ds['u'][num_halos:-(num_halos+1),num_halos:-num_halos,z]
-
-    rank = 0
-    plot_dir = 'compare_rusty'
-    plot_2d(f"shield", rank, attribute, shield_xy0, plot_dir=plot_dir)
-    plot_2d(f"pace", rank, attribute, pace_xy0, plot_dir=plot_dir)
-
-
-    os.makedirs(plot_dir, exist_ok=True)
-    diff = shield_xy0.data - pace_xy0.data
-    plt.title(f"diff: SHiELD - Pace for '{attribute}'")
-    plt.imshow(diff, cmap="viridis")
-    plt.colorbar()
-    plt.savefig(
-        os.path.join(
-            plot_dir,
-            f"test_diff_r{rank}_{attribute}.png"
-        )
-    )
-    plt.clf()
-
-    #not_zero_mask = diff[diff != 0] # TODO: jk zero comparison okay?
-    #norm_diff = diff.copy()
-    #norm_diff[not_zero_mask] = np.absolute((ds_values - state_values) / ds_values)
-    norm_diff = np.absolute((shield_xy0.data - pace_xy0.data) / shield_xy0.data)
-    plt.title(f"norm_diff: abs(Fortran - Pace / Fortran) for '{attribute}'")
-    plt.imshow(norm_diff, cmap="viridis")
-    plt.colorbar()
-    plt.savefig(
-        os.path.join(
-            plot_dir,
-            f"test_norm_diff_r{rank}_{attribute}.png"
-        )
-    )
-    plt.clf()
-
-    max_eps_error = 1e-12
-
-    shield_minus_pace = shield_xy0.data - pace_xy0.data
-    max_error_diff = np.max(
-        np.absolute((shield_minus_pace) / shield_xy0.data)
-    )
-    if np.isnan(max_error_diff): # e.g., from zero division
-        max_error_diff = np.max(np.absolute(shield_minus_pace))
-
-    assert max_error_diff < max_eps_error
+    assert not (state_instability.u.field == state_steady.u.field).all()

--- a/tests/main/fv3core/test_dycore_call.py
+++ b/tests/main/fv3core/test_dycore_call.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Tuple
 
 import pyFV3.initialization.analytic_init as ai
+from pyFV3.initialization.analytic_init import AnalyticCase
 from ndsl import (
     CompilationConfig,
     CubedSphereCommunicator,
@@ -108,12 +109,13 @@ def setup_dycore() -> Tuple[DynamicalCore, DycoreState, Timer]:
     # create an initial state from the Jablonowski & Williamson Baroclinic
     # test case perturbation. JRMS2006
     state = ai.init_analytic_state(
-        analytic_init_case="baroclinic",
+        analytic_init_case=AnalyticCase.baroclinic_instability,
         grid_data=grid_data,
         quantity_factory=quantity_factory,
         adiabatic=config.adiabatic,
         hydrostatic=config.hydrostatic,
         moist_phys=config.moist_phys,
+        sw_dynamics=config.sw_dynamics,
         comm=communicator,
     )
     stencil_factory = StencilFactory(

--- a/tests/main/fv3core/test_dycore_call.py
+++ b/tests/main/fv3core/test_dycore_call.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Tuple
 
 import pyFV3.initialization.analytic_init as ai
-from pyFV3.initialization.analytic_init import AnalyticCase
 from ndsl import (
     CompilationConfig,
     CubedSphereCommunicator,
@@ -24,6 +23,7 @@ from ndsl.grid import DampingCoefficients, GridData, MetricTerms
 from ndsl.performance.timer import NullTimer, Timer
 from ndsl.stencils.testing import assert_same_temporaries, copy_temporaries
 from pyFV3 import DycoreState, DynamicalCore, DynamicalCoreConfig
+from pyFV3.initialization.analytic_init import AnalyticCase
 
 
 def setup_dycore() -> Tuple[DynamicalCore, DycoreState, Timer]:


### PR DESCRIPTION
**Description**
* This PR will allow the Pace driver to run both the baroclinic instability (13) and steady state (12) test cases found in tools/test_cases.F90 of the [GFDL_atmos_cubed_sphere repo](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git).

* A new test case `baroclinic_steady` has been added. The previously existing `baroclinic` test case has been changed to `baroclinic_instability`.

* The Analytic test case has been changed from a string to an enumeration.

* For Analytic Initialization, the dycore config has been added to the InitalizerSelector so that the driver can have access to pass along the proper parameters during initialization. This is also useful for configuration consistency checks at initialization.

* Hooks can now be passed to the Pace registry. In this case, it is being used to convert the analytic test case string to AnalyticCase enumeration.

* Minor README changes have been made.

* This PR is dependent on the changes here: https://github.com/NOAA-GFDL/PyFV3/pull/64

Fixes # (issue)
None

**How Has This Been Tested?**
There are only basic unit tests being added with a placeholder and TODOs for more. (I don't have a good strategy to write quick unit tests yet. )

In addition to the unit tests, a comparison was made to zero time SHiELD results. The resulting max differences after initialization between SHiELD and pace results for phis, delp, u, v attributes were on the order of 10^-12.
[C48.solo.BCmoist.pace_test12_64_debug](https://github.com/jjuyeonkim/SHiELD_build/blob/20250522_bc_1/RTS/CI/C48.solo.BCmoist.pace_test12_64_debug)

However, a comparison was made to 1-day SHiELD results: [C48.solo.BCmoist.pace_test12_64_1day_dycoreonly_debug](https://github.com/jjuyeonkim/SHiELD_build/blob/20250522_bc_1/RTS/CI/C48.solo.BCmoist.pace_test12_64_1day_dycoreonly_debug) After 1 day, there was a difference in the pace results compared to SHiELD that needs further investigation. This difference also exists in the Baroclinic instability test case that existed prior to this PR.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules (This PR is dependent on the changes here: https://github.com/NOAA-GFDL/PyFV3/pull/64)
- [x] New check tests, if applicable, are included
