### PR TITLE
Fix: Base Ubuntu runner in workflow

### DIFF
--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -21,8 +21,6 @@ concurrency:
 jobs:
   pace_main_unit_tests:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/noaa-gfdl/miniforge:mpich
     steps:
       - name: "External trigger: Checkout pace/develop"
         if: ${{ inputs.component_trigger }}
@@ -32,6 +30,14 @@ jobs:
           repository: NOAA-GFDL/pace
           path: pace
           ref: develop
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install mpi (MPICH flavor)
+        run: pip install mpich
 
       - name: "External trigger: Remove existing component in pace/develop"
         if: ${{ inputs.component_trigger }}

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -67,4 +67,4 @@ jobs:
       - name: Run baroclinic test case
         run: |
           cd ${GITHUB_WORKSPACE}/pace
-          mpiexec -np 6 --oversubscribe python -m pace.run examples/configs/baroclinic_c48_no_out.yaml
+          mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c48_no_out.yaml

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -11,6 +11,7 @@ on:
         default: ''
         required: false
   pull_request:
+  push:
 
 # cancel running jobs if theres a newer push
 concurrency:


### PR DESCRIPTION
**Description**
This PR introduces changes to the workflow to enable bumping the version of `mpi4py > 4` as introduced in [PR 184 ](https://github.com/NOAA-GFDL/NDSL/pull/184)in NDSL

Fixes # (issue)
Fixes workflow issues for [PR 184](https://github.com/NOAA-GFDL/NDSL/pull/184) in NDSL

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
