### PR TITLE
ci: only run on push to main branch

### DIFF
--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -14,7 +14,9 @@ on:
         required: false
   pull_request: # ... a PR is opened / updated
   merge_group:  # ... the PR is added to the merge queue
-  push:         # ... code is pushed to any branch
+  push:
+    branches:
+      - main # ... when merging into the main branch
 
 # cancel running jobs if theres a newer push
 concurrency:


### PR DESCRIPTION
**Description**

A small follow-up from PR #133. I somehow missed that - sorry!

Currently, "pace main unit tests" run on push to any branch. In case of `develop`, this is redundant with the merge queue checks. In case of any branch that isn't protected (e.g. anything that is not the `main` branch), running ci isn't necessary. This is consistent with the linting workflow and other workflow configurations (e.g. PyFV3 and PySHiELD).

**How Has This Been Tested?**

Self-review of code. This is copied from other (working) workflows.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
