### PR TITLE
add workflow to test dockerfile builds

### DIFF
--- a/.github/workflows/container_build_test.yaml
+++ b/.github/workflows/container_build_test.yaml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - 'develop'
+  schedule:
+    - cron: '0 0 * * 0' # sundays @ midnight
+
+jobs:
+  test-container-builds:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Files
+      uses: actions/checkout@v5.0.0
+    - name: Build Dockerfile
+      uses: docker/build-push-action@v6.18.0
+      with:
+        context: .
+        push: false
+        file: "Dockerfile"
+    - name: Build Dockerfile.nvhpc
+      uses: docker/build-push-action@v6.18.0
+      with:
+        context: .
+        push: false
+        file: "Dockerfile.nvhpc"

--- a/.github/workflows/container_build_test.yaml
+++ b/.github/workflows/container_build_test.yaml
@@ -11,15 +11,11 @@ jobs:
     steps:
     - name: Checkout Files
       uses: actions/checkout@v5.0.0
+      with:
+        submodules: recursive
     - name: Build Dockerfile
       uses: docker/build-push-action@v6.18.0
       with:
         context: .
         push: false
         file: "Dockerfile"
-    - name: Build Dockerfile.nvhpc
-      uses: docker/build-push-action@v6.18.0
-      with:
-        context: .
-        push: false
-        file: "Dockerfile.nvhpc"

--- a/.github/workflows/container_build_test.yaml
+++ b/.github/workflows/container_build_test.yaml
@@ -9,13 +9,13 @@ jobs:
   test-container-builds:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Files
-      uses: actions/checkout@v5.0.0
-      with:
-        submodules: recursive
-    - name: Build Dockerfile
-      uses: docker/build-push-action@v6.18.0
-      with:
-        context: .
-        push: false
-        file: "Dockerfile"
+      - name: Checkout Files
+        uses: actions/checkout@v5.0.0
+        with:
+          submodules: recursive
+      - name: Build Dockerfile
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          push: false
+          file: "Dockerfile"


### PR DESCRIPTION
**Description**
adds a workflow to test the Dockerfile build works. runs on pushes to develop and weekly.

Lmk if we want to build the nvhpc one too, it would just have to be in a different job due to size constraints on the free runners.

**How Has This Been Tested?**
tested on my fork: https://github.com/rem1776/pace/actions/runs/17306326176/job/49130057058

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
