### PR TITLE
Fix: Adding oversubscribe flag for baroclinic instability run in workflow

### DIFF
--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install mpi (MPICH flavor)
         shell: bash -l {0}
-        run: conda install -c conda-forge mpich
+        run: conda install -c conda-forge mpi4py mpich
 
       - name: "External trigger: Remove existing component in pace/develop"
         shell: bash -l {0}

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -44,9 +44,9 @@ jobs:
           auto-activate-base: false
           activate-environment: pace_test_env
 
-      # - name: Install mpi (MPICH flavor)
-      #   shell: bash -l {0}
-      #   run: pip install mpich
+      - name: Install mpi (MPICH flavor)
+        shell: bash -l {0}
+        run: conda install -c conda-forge mpich
 
       - name: "External trigger: Remove existing component in pace/develop"
         shell: bash -l {0}

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install mpi (MPICH flavor)
         shell: bash -l {0}
-        run: conda install -c conda-forge mpi4py mpich
+        run: pip install mpich
 
       - name: "External trigger: Remove existing component in pace/develop"
         shell: bash -l {0}

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -32,9 +32,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          repository: NOAA-GFDL/pace
+          repository: fmalatino/pace
           path: pace
-          ref: develop
+          ref: conda-ci
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -44,9 +44,9 @@ jobs:
           auto-activate-base: false
           activate-environment: pace_test_env
 
-      - name: Install mpi (MPICH flavor)
-        shell: bash -l {0}
-        run: pip install mpich
+      # - name: Install mpi (MPICH flavor)
+      #   shell: bash -l {0}
+      #   run: pip install mpich
 
       - name: "External trigger: Remove existing component in pace/develop"
         shell: bash -l {0}

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -32,9 +32,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          repository: fmalatino/pace
+          repository: NOAA-GFDL/pace
           path: pace
-          ref: conda-ci
+          ref: develop
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          repository: NOAA-GFDL/pace
+          repository: fmalatino/pace
           path: pace
           ref: develop
 

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -36,15 +36,20 @@ jobs:
           path: pace
           ref: develop
 
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: '3.11'
+          python-version: 3.11.13
+          conda-remove-defaults: true
+          auto-activate-base: false
+          activate-environment: pace_test_env
 
       - name: Install mpi (MPICH flavor)
+        shell: bash -l {0}
         run: pip install mpich
 
       - name: "External trigger: Remove existing component in pace/develop"
+        shell: bash -l {0}
         if: ${{ inputs.component_trigger }}
         run: rm -rf ${GITHUB_WORKSPACE}/pace/${{inputs.component_name}}
 
@@ -55,28 +60,35 @@ jobs:
           path: pace/${{inputs.component_name}}
 
       - name: Install packages
+        shell: bash -l {0}
         run: |
           cd ${GITHUB_WORKSPACE}/pace
           pip install .[test]
+          pip install numpy==1.26.4
+          conda remove sqlite
 
       - name: Print versions
+        shell: bash -l {0}
         run: |
           python --version
           pip --version
           pip list
 
       - name: Prepare input files
+        shell: bash -l {0}
         run: |
           cd ${GITHUB_WORKSPACE}/pace
           mkdir tests/main/input
           python examples/generate_eta_files.py tests/main/input
 
       - name: Run tests
+        shell: bash -l {0}
         run: |
           cd ${GITHUB_WORKSPACE}/pace
           python -m pytest -x tests/main
 
       - name: Run baroclinic test case
+        shell: bash -l {0}
         run: |
           cd ${GITHUB_WORKSPACE}/pace
           mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c48_no_out.yaml

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          repository: fmalatino/pace
+          repository: NOAA-GFDL/pace
           path: pace
           ref: develop
 

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -91,4 +91,4 @@ jobs:
         shell: bash -l {0}
         run: |
           cd ${GITHUB_WORKSPACE}/pace
-          mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c48_no_out.yaml
+          mpiexec -np 6 --oversubscribe python -m pace.run examples/configs/baroclinic_c48_no_out.yaml


### PR DESCRIPTION
**Description**
This PR applies the `--oversubscribe` flag for the baroclinic instability test that is run during the workflow. Previous PRs were not passing this test due to a lack of available cores for the runner.

**How Has This Been Tested?**
Tested using currently implemented unit tests

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
