### PR TITLE
ci: Update actions/checkout v4 -> v5

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: "External trigger: Checkout pace/develop"
         if: ${{ inputs.component_trigger }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           repository: NOAA-GFDL/pace
@@ -54,7 +54,7 @@ jobs:
         run: rm -rf ${GITHUB_WORKSPACE}/pace/${{inputs.component_name}}
 
       - name: Checkout out hash that triggered CI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           path: pace/${{inputs.component_name}}


### PR DESCRIPTION
**Description**

This PR updates actions/checkout from @v4 to @v5. The major version number update was only necessary because of new requirements on the runners (which is a breaking change). Since we use runners provided by GitHub, we don't have to worry.

**How Has This Been Tested?**

All good as long as CI still runs (and is green).

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
