### PR TITLE
ci: cache pre-commit environment between PR runs

### DIFF
--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -1,0 +1,44 @@
+name: "Create GHA cache"
+
+# GitHub puts the following restrictions on cache sharing. PRs can access
+#
+# - caches that were created by the PR / earlier runs of the PR
+# - caches that were created on the target branch
+#
+# To get effective cache sharing between PRs, we create caches on the `develop`
+# branch (which is where almost all PRs merge into).
+
+on:
+  push:
+    branches: [develop]
+
+# Cancel running jobs if there's a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # GitHub Actions cache of the pre-commit environment
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit_${{ env.pythonLocation }}_${{ hashFiles('.pre-commit-config.yaml') }}
+          lookup-only: true  # don't actually download the cache
+
+      - name: Populate pre-commit environment (if not cached)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          pip install pre-commit
+          pre-commit install --install-hooks

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,14 +17,20 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Step Python 3.11.9
+      - name: Step Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11.9'
+          python-version: '3.11'
+
+      # Only restore (don't save) caches on PRs. New caches created from PRs won't be
+      # accessible from other PRs, see workflows/create-cache.yaml.
+      - uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit_${{ env.pythonLocation }}_${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Install pre-commit
         run: pip install pre-commit
 
       - name: Run lint via pre-commit
-        run: |
-          pre-commit run --all-files
+        run: pre-commit run --all-files


### PR DESCRIPTION
**Description**

This PR add support for caching the pre-commit environment in GHA linting workflows. GitHub imposes the following rules on cache sharing. Caches can be restored by a workflow if

1. they were created by a previous run of the workflow
2. they were created by the target branch of this PR

We thus add an explicit cache creation workflow that runs when ever we merge into `develop`. This PR will create caches that can be reused (as intended by 2) above) by any PR targeting the `develop` branch.

**How Has This Been Tested?**

This is a propagation of PR https://github.com/NOAA-GFDL/NDSL/pull/202 in NDSL, which works as advertised. I'll double check after the first run that this also works as intended in this repository. If not, I'll do follow-up PRs in a timely manner.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
