### PR TITLE
refactor: use new versions of environment variables in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ After the run completes, you will see an output directory `output.zarr`. An exam
 
 ### Environment variable configuration
 
-- `PACE_CONSTANTS`: Pace is bundled with various constants.
+- `NDSL_CONSTANTS`: Pace is bundled with various constants.
   - `GFDL` NOAA's FV3 dynamical core constants (original port)
   - `GFS` Constant as defined in NOAA GFS
   - `GEOS`  Constant as defined in GEOS v13
-- `PACE_FLOAT_PRECISION`: default precision of the field & scalars in the numerics. Default to 64.
-- `PACE_LOGLEVEL`: logging level to display (DEBUG, INFO, WARNING, ERROR, CRITICAL). Default to INFO.
+- `NDSL_LITERAL_PRECISION`: default precision of the field & scalars in the numerics. Default to 64.
+- `NDSL_LOGLEVEL`: logging level to display (DEBUG, INFO, WARNING, ERROR, CRITICAL). Default to INFO.
 
 ## Quickstart - Docker
 

--- a/doc_primer_orchestration.md
+++ b/doc_primer_orchestration.md
@@ -45,7 +45,7 @@ DaCe has many configuration options. When executing, it drops or reads a `dace.c
 
 `ndsl.dsl.dace.dace_config` carries a set of tested options for DaCe, with doc. It also takes care of removing the `dace.conf` that will be generated automatically when using DaCe.
 
-Orchestration can be debugged by using the env var `PACE_DACE_DEBUG`.
+Orchestration can be debugged by using the env var `NDSL_DACE_DEBUG`.
 When set to `True`, this will drop a few checks:
 
 - `sdfg_nan_checker`, which drops a NaN check after _every_ computation on field _written_,

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -11,4 +11,4 @@ A few environment variable change the behavior of the model:
   - Build: will build the program then exit. This _build no matter what_. (backend must be `dace:gpu` or `dace:cpu`)
   - BuildAndRun: same as above but after build the program will keep executing (backend must be `dace:gpu` or `dace:cpu`)
   - Run: load pre-compiled program and execute, fail if the .so is not present (_no hashs check!_) (backend must be `dace:gpu` or `dace:cpu`)
-- PACE_FLOAT_PRECISION=64 control the floating point precision throughout the program.
+- NDSL_LITERAL_PRECISION=64 control the floating point precision throughout the program.


### PR DESCRIPTION
**Description**

The old ones are currently deprecated and expected to be removed in the future (after a grace period). See
https://github.com/NOAA-GFDL/NDSL/pull/193 for more details. Apparently pace (and its tests) doesn't set any of those (which is fine). We should nevertheless update the docs for people to use the new ones.

**How Has This Been Tested?**

Self-review of code changes.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
