### PR TITLE
refactor: change tests to use quantities allocated by gt4py

### DIFF
--- a/tests/main/test_grid_init.py
+++ b/tests/main/test_grid_init.py
@@ -25,9 +25,9 @@ def get_cube_comm(layout, rank: int):
 def get_quantity_factory(layout, nx_tile, ny_tile, nz):
     nx = nx_tile // layout[0]
     ny = ny_tile // layout[1]
-    return QuantityFactory(
+    return QuantityFactory.from_backend(
         sizer=SubtileGridSizer(nx=nx, ny=ny, nz=nz, n_halo=3, extra_dim_lengths={}),
-        numpy=np,
+        backend="numpy",
     )
 
 

--- a/tests/mpi/test_grid_init.py
+++ b/tests/mpi/test_grid_init.py
@@ -27,9 +27,9 @@ def get_cube_comm(layout, comm: MPIComm):
 def get_quantity_factory(layout, nx_tile, ny_tile, nz):
     nx = nx_tile // layout[0]
     ny = ny_tile // layout[1]
-    return QuantityFactory(
+    return QuantityFactory.from_backend(
         sizer=SubtileGridSizer(nx=nx, ny=ny, nz=nz, n_halo=3, extra_dim_lengths={}),
-        numpy=np,
+        backend="numpy",
     )
 
 


### PR DESCRIPTION
**Description**

Move pace tests away from numpy allocated memory over to gt4py allocated memory. This is forward compatible with expected changes in NDSL, e.g. https://github.com/NOAA-GFDL/NDSL/pull/228.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
