### PR TITLE
ci: fix test runs that broke out of nowhere

### DIFF
--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -39,13 +39,10 @@ jobs:
           path: pace
           ref: develop
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11.13
-          conda-remove-defaults: true
-          auto-activate-base: false
-          activate-environment: pace_test_env
+          python-version: '3.11'
 
       - name: Install mpi (MPICH flavor)
         run: pip install mpich

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -50,6 +50,10 @@ jobs:
       - name: Install mpi (MPICH flavor)
         run: pip install mpich
 
+      - name: Install numpy==1.26.4
+        # Front-load installing numpy to force it's usage
+        run: pip install numpy==1.26.4
+
       - name: "External trigger: Remove existing component in pace/develop"
         if: ${{ inputs.component_trigger }}
         run: rm -rf ${GITHUB_WORKSPACE}/pace/${{inputs.component_name}}
@@ -64,7 +68,6 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/pace
           pip install .[test]
-          pip install numpy==1.26.4
 
       - name: Print versions
         run: |

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -48,7 +48,10 @@ jobs:
         run: pip install mpich
 
       - name: Install numpy==1.26.4
-        # Front-load installing numpy to force it's usage
+        # Front-load installing numpy to force its usage in the radiation
+        # scheme of pySHiELD.
+        # TODO: This is an ugly hack and it should be cleaned up latest once
+        #       we add support for numpy >= 2.0
         run: pip install numpy==1.26.4
 
       - name: "External trigger: Remove existing component in pace/develop"


### PR DESCRIPTION
**Description**

CI broke again out of nowhere today. This seems to stabilize CI for now.

Front-loading numpy itself didn't make a difference, but is good practice. The radiation scheme from pySHiELD will pick it up if it's installed already in the environment.

Replacing the miniconda setup with a plain python GHA setup seems to do the trick. I have to admit that I don't fully understand the breakage. My hunch is that the miniconda setup somehow interfered with how pip resolves dependencies and then either two incompatible packages were installed or there were somehow two different python environments floating around.

**How Has This Been Tested?**

CI failed before (see [this run](https://github.com/NOAA-GFDL/pace/actions/runs/18560484839/job/52908012267) that added just an empty file) and is running green again with these changes.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
  N/A
- [ ] New check tests, if applicable, are included
  N/A
