### PR TITLE
Temporary Dycore dacite Config + Dycore Config Type Check Tweak  [see: PyFV3 PR #88]

### DIFF
--- a/pace/driver.py
+++ b/pace/driver.py
@@ -239,10 +239,21 @@ class DriverConfig:
                         "as it is determined based on top-level configuration"
                     )
 
+            # TODO - After pyFV3 PR #88, replace dycore dacite cmd with:
+            # kwargs["dycore_config"] = DynamicalCoreConfig.from_dict(
+            #     kwargs.get("dycore_config", {})
+            # )
+            dycore_dacite_config = dacite.Config(
+                strict=True,
+                type_hooks={
+                    Tuple[int, int]: lambda x: tuple(x),
+                    Tuple[str, ...]: lambda x: tuple(x) if x is not None else None,
+                },
+            )
             kwargs["dycore_config"] = dacite.from_dict(
                 data_class=DynamicalCoreConfig,
                 data=kwargs.get("dycore_config", {}),
-                config=dacite.Config(strict=True),
+                config=dycore_dacite_config,
             )
 
         if isinstance(kwargs["physics_config"], dict):

--- a/tests/main/fv3core/test_config.py
+++ b/tests/main/fv3core/test_config.py
@@ -42,7 +42,9 @@ def assert_types_match(classes):
     types = collections.defaultdict(set)
     for cls in classes:
         for name, field in cls.__dataclass_fields__.items():
-            types[name].add(field.type)
+            # Get type hints in case we're using postponed evaluation of types
+            # Example: '<class 'bool'> instead of 'bool'
+            types[name].add(typing.get_type_hints(cls)[name])
         for name, attr in cls.__dict__.items():
             if isinstance(attr, property):
                 types[name].add(


### PR DESCRIPTION
**Description**
Modifying the `dacite.Config` for creating a `DynamicalCoreConfig`. This is a proposed temporary solution to get the CI to pass for [PyFV3 PR #88](https://github.com/NOAA-GFDL/PyFV3/actions/runs/18543571254/job/52921838101?pr=88), which is part of [NDSL Issue #64](https://github.com/NOAA-GFDL/NDSL/issues/64).

These type_hooks are to support proposed future changes to the `DynamicalCoreConfig` to allow for tuples to be created properly from lists potentially from a `yaml.safe_load`. Eventually, I'd like to change this to the following once [PyFV3 PR #88](https://github.com/NOAA-GFDL/PyFV3/pull/88) is merged:

`kwargs["dycore_config"] = DynamicalCoreConfig.from_dict(kwargs.get("dycore_config", {})
`
where how `dacite` is used is left up to the submodule via the config.

Also -- Tweaking one of the pace unit tests that performs type checks in the dycore config.

**How Has This Been Tested?**
Existing CI tests pass

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
