### PR TITLE
Tmp dacite.Config for PhysicsConfig + PyFV3 module update + Clean-up

### DIFF
--- a/pace/driver.py
+++ b/pace/driver.py
@@ -238,29 +238,26 @@ class DriverConfig:
                         f"you cannot set {derived_name} directly in dycore_config, "
                         "as it is determined based on top-level configuration"
                     )
+            kwargs["dycore_config"] = DynamicalCoreConfig.from_dict(
+                kwargs.get("dycore_config", {})
+            )
 
-            # TODO - After pyFV3 PR #88, replace dycore dacite cmd with:
-            # kwargs["dycore_config"] = DynamicalCoreConfig.from_dict(
-            #     kwargs.get("dycore_config", {})
+        if isinstance(kwargs["physics_config"], dict):
+            # TODO - After pySHiELD PR #68, replace physics dacite cmd with:
+            # kwargs["physics_config"] = PhysicsConfig.from_dict(
+            #     kwargs.get("physics_config", {})
             # )
-            dycore_dacite_config = dacite.Config(
+            phys_dacite_config = dacite.Config(
                 strict=True,
                 type_hooks={
                     Tuple[int, int]: lambda x: tuple(x),
                     Tuple[str, ...]: lambda x: tuple(x) if x is not None else None,
                 },
             )
-            kwargs["dycore_config"] = dacite.from_dict(
-                data_class=DynamicalCoreConfig,
-                data=kwargs.get("dycore_config", {}),
-                config=dycore_dacite_config,
-            )
-
-        if isinstance(kwargs["physics_config"], dict):
             kwargs["physics_config"] = dacite.from_dict(
                 data_class=PhysicsConfig,
                 data=kwargs.get("physics_config", {}),
-                config=dacite.Config(strict=True),
+                config=phys_dacite_config,
             )
 
         kwargs["layout"] = tuple(kwargs["layout"])


### PR DESCRIPTION
**Description**
These are proposed modifications to get the CI to pass for [PySHiELD PR #68](https://github.com/NOAA-GFDL/PySHiELD/pull/68), which is part of [NDSL Issue #64](https://github.com/NOAA-GFDL/NDSL/issues/64).

1. Modifying the `dacite.Config` for creating a `PhysicsConfig`.  The added type_hooks are to support proposed future changes to the `PhysicsConfig` to allow for tuples to be created properly from lists potentially from a `yaml.safe_load`. Eventually, I'd like to eventually change it to the following once [PySHiELD PR #68](https://github.com/NOAA-GFDL/PySHiELD/pull/68) is merged:`kwargs["physics_config"] = PhysicsConfig.from_dict(kwargs.get("physics_config", {})`, where how `dacite` is used is left up to the submodule via the config.
2. Also, there is clean-up from Pace PR #152  , which is why the pyFV3 submodule has been updated to get the most recent changes from [PyFV3 PR #68](https://github.com/NOAA-GFDL/PyFV3/pull/88).

**How Has This Been Tested?**
Existing CI tests pass

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules - Dependent on: [PyFV3 PR #90](https://github.com/NOAA-GFDL/PyFV3/pull/90) to fix linting error
- [ ] New check tests, if applicable, are included