### PR TITLE
GridSizer API: Use `fom_tile_params` instead of direct constructor of `dataclass`

### DIFF
--- a/tests/main/driver/test_diagnostics_config.py
+++ b/tests/main/driver/test_diagnostics_config.py
@@ -43,7 +43,9 @@ def test_zselect_raises_error_if_not_3d(tmpdir):
         )
         result = config.diagnostics_factory(unittest.mock.MagicMock())
         quantity_factory = QuantityFactory.from_backend(
-            sizer=SubtileGridSizer(nx=12, ny=12, nz=79, n_halo=3, extra_dim_lengths={}),
+            sizer=SubtileGridSizer.from_tile_params(
+                nx=12, ny=12, nz=79, n_halo=3, extra_dim_lengths={}, layout=(1, 1)
+            ),
             backend="numpy",
         )
         state = DycoreState.init_zeros(quantity_factory)
@@ -58,7 +60,9 @@ def test_zselect_raises_error_if_3rd_dim_not_z(tmpdir):
         )
         result = config.diagnostics_factory(unittest.mock.MagicMock())
         quantity_factory = QuantityFactory.from_backend(
-            sizer=SubtileGridSizer(nx=12, ny=12, nz=79, n_halo=3, extra_dim_lengths={}),
+            sizer=SubtileGridSizer.from_tile_params(
+                nx=12, ny=12, nz=79, n_halo=3, extra_dim_lengths={}, layout=(1, 1)
+            ),
             backend="numpy",
         )
         state = DycoreState.init_zeros(quantity_factory)

--- a/tests/main/driver/test_diagnostics_config.py
+++ b/tests/main/driver/test_diagnostics_config.py
@@ -67,7 +67,7 @@ def test_zselect_raises_error_if_3rd_dim_not_z(tmpdir):
         quantity_factory = QuantityFactory.from_backend(
             sizer=SubtileGridSizer.from_tile_params(
                 nx_tile=12,
-                ny_tuke=12,
+                ny_tile=12,
                 nz=79,
                 n_halo=3,
                 extra_dim_lengths={},

--- a/tests/main/driver/test_diagnostics_config.py
+++ b/tests/main/driver/test_diagnostics_config.py
@@ -44,7 +44,12 @@ def test_zselect_raises_error_if_not_3d(tmpdir):
         result = config.diagnostics_factory(unittest.mock.MagicMock())
         quantity_factory = QuantityFactory.from_backend(
             sizer=SubtileGridSizer.from_tile_params(
-                nx=12, ny=12, nz=79, n_halo=3, extra_dim_lengths={}, layout=(1, 1)
+                nx_tile=12,
+                ny_tile=12,
+                nz=79,
+                n_halo=3,
+                extra_dim_lengths={},
+                layout=(1, 1),
             ),
             backend="numpy",
         )
@@ -61,7 +66,12 @@ def test_zselect_raises_error_if_3rd_dim_not_z(tmpdir):
         result = config.diagnostics_factory(unittest.mock.MagicMock())
         quantity_factory = QuantityFactory.from_backend(
             sizer=SubtileGridSizer.from_tile_params(
-                nx=12, ny=12, nz=79, n_halo=3, extra_dim_lengths={}, layout=(1, 1)
+                nx_tile=12,
+                ny_tuke=12,
+                nz=79,
+                n_halo=3,
+                extra_dim_lengths={},
+                layout=(1, 1),
             ),
             backend="numpy",
         )

--- a/tests/main/test_grid_init.py
+++ b/tests/main/test_grid_init.py
@@ -26,7 +26,13 @@ def get_quantity_factory(layout, nx_tile, ny_tile, nz):
     nx = nx_tile // layout[0]
     ny = ny_tile // layout[1]
     return QuantityFactory.from_backend(
-        sizer=SubtileGridSizer(nx=nx, ny=ny, nz=nz, n_halo=3, extra_dim_lengths={}),
+        sizer=SubtileGridSizer(
+            nx_tile=nx,
+            ny_tile=ny,
+            nz=nz,
+            n_halo=3,
+            extra_dim_lengths={},
+        ),
         backend="numpy",
     )
 

--- a/tests/main/test_grid_init.py
+++ b/tests/main/test_grid_init.py
@@ -32,6 +32,7 @@ def get_quantity_factory(layout, nx_tile, ny_tile, nz):
             nz=nz,
             n_halo=3,
             extra_dim_lengths={},
+            layout=(1, 1),
         ),
         backend="numpy",
     )

--- a/tests/main/test_grid_init.py
+++ b/tests/main/test_grid_init.py
@@ -26,7 +26,7 @@ def get_quantity_factory(layout, nx_tile, ny_tile, nz):
     nx = nx_tile // layout[0]
     ny = ny_tile // layout[1]
     return QuantityFactory.from_backend(
-        sizer=SubtileGridSizer(
+        sizer=SubtileGridSizer.from_tile_params(
             nx_tile=nx,
             ny_tile=ny,
             nz=nz,

--- a/tests/mpi/test_grid_init.py
+++ b/tests/mpi/test_grid_init.py
@@ -28,7 +28,9 @@ def get_quantity_factory(layout, nx_tile, ny_tile, nz):
     nx = nx_tile // layout[0]
     ny = ny_tile // layout[1]
     return QuantityFactory.from_backend(
-        sizer=SubtileGridSizer(nx=nx, ny=ny, nz=nz, n_halo=3, extra_dim_lengths={}),
+        sizer=SubtileGridSizer.from_tile_params(
+            nx=nx, ny=ny, nz=nz, n_halo=3, extra_dim_lengths={}, layout=(1, 1)
+        ),
         backend="numpy",
     )
 


### PR DESCRIPTION
**Description**

Nomalize the use of `from_tile_params` as a first step to an API clean up coming from NDSL in https://github.com/NOAA-GFDL/NDSL/pull/272

**How Has This Been Tested?**

This is using an existing API - trivial.

