### PR TITLE
Removing ndsl.Namelist from Pace

### DIFF
--- a/pace/driver.py
+++ b/pace/driver.py
@@ -243,21 +243,8 @@ class DriverConfig:
             )
 
         if isinstance(kwargs["physics_config"], dict):
-            # TODO - After pySHiELD PR #68, replace physics dacite cmd with:
-            # kwargs["physics_config"] = PhysicsConfig.from_dict(
-            #     kwargs.get("physics_config", {})
-            # )
-            phys_dacite_config = dacite.Config(
-                strict=True,
-                type_hooks={
-                    Tuple[int, int]: lambda x: tuple(x),
-                    Tuple[str, ...]: lambda x: tuple(x) if x is not None else None,
-                },
-            )
-            kwargs["physics_config"] = dacite.from_dict(
-                data_class=PhysicsConfig,
-                data=kwargs.get("physics_config", {}),
-                config=phys_dacite_config,
+            kwargs["physics_config"] = PhysicsConfig.from_dict(
+                kwargs.get("physics_config", {})
             )
 
         kwargs["layout"] = tuple(kwargs["layout"])

--- a/pace/grid.py
+++ b/pace/grid.py
@@ -6,7 +6,7 @@ from typing import ClassVar, Optional, Tuple
 import f90nml
 import xarray as xr
 
-from ndsl import Namelist, QuantityFactory, ndsl_log
+from ndsl import QuantityFactory, ndsl_log
 from ndsl.comm.partitioner import get_tile_index
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM
 from ndsl.grid import (
@@ -22,6 +22,7 @@ from ndsl.grid import (
 from ndsl.grid.stretch_transformation import direct_transform
 from ndsl.stencils.testing import TranslateGrid, grid
 from ndsl.typing import Communicator
+from ndsl.utils import grid_params_from_f90nml
 from pace.registry import Registry
 
 
@@ -151,8 +152,8 @@ class SerialboxGridConfig(GridInitializer):
         return f90nml.read(self.path + "/input.nml")
 
     @property
-    def _namelist(self) -> Namelist:
-        return Namelist.from_f90nml(self._f90_namelist)
+    def _grid_params(self) -> dict:
+        return grid_params_from_f90nml(self._f90_namelist)
 
     def _serializer(self, communicator: Communicator):
         import serialbox
@@ -171,7 +172,7 @@ class SerialboxGridConfig(GridInitializer):
     ) -> grid.Grid:  # type: ignore
         ser = self._serializer(communicator)
         grid = TranslateGrid.new_from_serialized_data(
-            ser, communicator.rank, self._namelist.layout, backend
+            ser, communicator.rank, self._grid_params["layout"], backend
         ).python_grid()
         return grid
 

--- a/pace/initialization.py
+++ b/pace/initialization.py
@@ -11,7 +11,6 @@ import pyfv3.initialization.analytic_init as analytic_init
 from ndsl import (
     CompilationConfig,
     DaceConfig,
-    Namelist,
     QuantityFactory,
     StencilConfig,
     StencilFactory,
@@ -20,6 +19,7 @@ from ndsl.constants import X_DIM, Y_DIM
 from ndsl.grid import DampingCoefficients, DriverGridData, GridData
 from ndsl.stencils.testing import TranslateGrid, grid
 from ndsl.typing import Communicator
+from ndsl.utils import grid_params_from_f90nml
 from pace.registry import Registry
 from pace.state import DriverState, TendencyState, _restart_driver_state
 from pyfv3 import DycoreState, DynamicalCoreConfig
@@ -253,8 +253,8 @@ class SerialboxInit(Initializer):
         return f90nml.read(self.path + "/input.nml")
 
     @property
-    def _namelist(self) -> Namelist:
-        return Namelist.from_f90nml(self._f90_namelist)
+    def _grid_params(self) -> dict:
+        return grid_params_from_f90nml(self._f90_namelist)
 
     def _get_serialized_grid(
         self,
@@ -263,7 +263,7 @@ class SerialboxInit(Initializer):
     ) -> grid.Grid:  # type: ignore
         ser = self._serializer(communicator)
         grid = TranslateGrid.new_from_serialized_data(
-            ser, communicator.rank, self._namelist.layout, backend
+            ser, communicator.rank, self._grid_params["layout"], backend
         ).python_grid()
         return grid
 
@@ -318,8 +318,8 @@ class SerialboxInit(Initializer):
         dace_config = DaceConfig(
             communicator,
             backend,
-            tile_nx=self._namelist.npx,
-            tile_nz=self._namelist.npz,
+            tile_nx=self._grid_params["npx"],
+            tile_nz=self._grid_params["npz"],
         )
         stencil_config = StencilConfig(
             compilation_config=CompilationConfig(
@@ -330,7 +330,9 @@ class SerialboxInit(Initializer):
         stencil_factory = StencilFactory(
             config=stencil_config, grid_indexing=grid.grid_indexing
         )
-        translate_object = TranslateFVDynamics(grid, self._namelist, stencil_factory)
+        translate_object = TranslateFVDynamics(
+            grid, self._f90_namelist, stencil_factory
+        )
         input_data = translate_object.collect_input_data(ser, savepoint_in)
         dycore_state = translate_object.state_from_inputs(input_data)
         return dycore_state


### PR DESCRIPTION
**Description**
- Removes ndsl.Namelist from Pace
- Cleans up direct dacite usage for `PhysicsConfig` creation, using `PhysicsConfig.from_dict` instead.

This follows from [PySHiELD PR #68](https://github.com/NOAA-GFDL/PySHiELD/pull/68), [PyFV3 PR #88](https://github.com/NOAA-GFDL/PyFV3/pull/88) and  [NDSL PR #246](https://github.com/NOAA-GFDL/NDSL/pull/246). It is part of [NDSL Issue # 64](https://github.com/NOAA-GFDL/NDSL/issues/64).

This is intended to be the last PR before finally removing `ndsl.Namelist`.

**How Has This Been Tested?**
- Existing unit tests and CI translate tests pass.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
