### PR TITLE
Add GitHub Actions workflow for documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,63 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:  # Allow manual trigger
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_docs.txt
+          # Install pace packages for autodoc
+          pip install -e . || true
+
+      - name: Build documentation
+        run: |
+          cd docs
+          make html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    # Only deploy on push to main/develop, not on PRs
+    if: github.event_name == 'push'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,8 @@ sys.path.insert(0, os.path.abspath("../driver"))
 # -- Project information -----------------------------------------------------
 
 project = "Pace"
-copyright = "2022, AI2 Climate Modeling Team"
-author = "AI2 Climate Modeling Team"
+copyright = "2022-2025, NOAA-GFDL (originally developed by AI2 Climate Modeling Team)"
+author = "NOAA-GFDL"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to build and deploy documentation to GitHub Pages
- Update documentation copyright/authorship to reflect NOAA-GFDL ownership
- Enables GFDL team to maintain documentation without external dependencies

## Background

Issue #67 identified that Pace documentation is currently hosted at `ai2cm.github.io/pace/`, which is controlled by AI2 and cannot be edited by the GFDL team. This PR migrates documentation hosting to the NOAA-GFDL repository's own GitHub Pages.

## Changes

### 1. New file: `.github/workflows/docs.yml`

GitHub Actions workflow that:
- Triggers on push to `main`/`develop` branches
- Builds Sphinx documentation using existing `docs/` configuration
- Deploys to GitHub Pages on the NOAA-GFDL repository
- Runs on PRs (build only, no deploy) for validation

### 2. Modified: `docs/conf.py`

Updated project metadata:
```python
# Before
copyright = "2022, AI2 Climate Modeling Team"
author = "AI2 Climate Modeling Team"

# After
copyright = "2022-2025, NOAA-GFDL (originally developed by AI2 Climate Modeling Team)"
author = "NOAA-GFDL"
```

## Post-Merge Setup Required

After merging, a repository admin needs to:

1. Go to **Settings → Pages**
2. Set **Source** to "GitHub Actions"
3. Documentation will then be available at `noaa-gfdl.github.io/Pace/`

## Test Plan

- [x] Sphinx build succeeds locally (`cd docs && make html`)
- [x] Build produces 17 HTML pages with no errors
- [x] Copyright reflects NOAA-GFDL in generated HTML
- [ ] GitHub Actions workflow runs successfully (verify after push)
- [ ] Documentation accessible at new URL (verify after Pages setup)

## Impact

- **No breaking changes** to existing functionality
- **Backward compatible** - existing RTD config preserved for reference
- **Enables** community contributions to documentation
- **Removes** dependency on external AI2 infrastructure

Fixes #67