### PR TITLE
refactor: prefer `get_tile_index()` over `get_tile_number()`

### DIFF
--- a/tests/mpi/ext_grid/test_external_grid.py
+++ b/tests/mpi/ext_grid/test_external_grid.py
@@ -11,7 +11,7 @@ from ndsl import (
     MPIComm,
     TilePartitioner,
 )
-from ndsl.comm.partitioner import get_tile_number
+from ndsl.comm.partitioner import get_tile_index
 from ndsl.constants import PI, RADIUS, X_INTERFACE_DIM, Y_INTERFACE_DIM
 from pace import Driver, DriverConfig
 from tests.paths import EXAMPLE_CONFIGS_DIR, REPO_ROOT
@@ -33,7 +33,7 @@ def get_cube_comm(layout, comm: MPIComm):
 
 
 def get_tile_num(comm: MPIComm):
-    return get_tile_number(comm.rank, comm.partitioner.total_ranks)
+    return get_tile_index(comm.rank, comm.partitioner.total_ranks) + 1
 
 
 # TODO: Location of test configurations and data will be changed


### PR DESCRIPTION
**Description**

`get_tile_number()` is deprecated and replaced by the zero-index version called `get_tile_index()`. This removes a `FutureWarning`, see

https://github.com/NOAA-GFDL/NDSL/blob/753fa24b549c3d51c29aed0d01ee018d3af3e9c9/ndsl/comm/partitioner.py#L36-L58

for context.

**How Has This Been Tested?**

Tested by doing a (self-)review of the code changes.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
