### PR TITLE
refactor: use new constructor of `QuantityFactory`

### DIFF
--- a/docs/physics/state.rst
+++ b/docs/physics/state.rst
@@ -35,7 +35,7 @@ You can initialize a zero-filled PhysicsState and MicrophysicsState from other P
     ...    tile_rank=communicator.tile.rank,
     ... )
 
-    >>> quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend="numpy")
+    >>> quantity_factory = QuantityFactory(sizer=sizer, backend="numpy")
     >>> physics_state = PhysicsState.init_zeros(
     ...  quantity_factory=quantity_factory, schemes=["GFS_microphysics"]
     ... )

--- a/examples/notebooks/functions.py
+++ b/examples/notebooks/functions.py
@@ -268,7 +268,7 @@ def configure_domain(
         tile_rank=communicator.tile.rank,
     )
 
-    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+    quantity_factory = QuantityFactory(sizer=sizer, backend=backend)
 
     metric_terms = MetricTerms(
         quantity_factory=quantity_factory,

--- a/examples/notebooks/grid_generation.ipynb
+++ b/examples/notebooks/grid_generation.ipynb
@@ -188,7 +188,7 @@
     ")\n",
     "\n",
     "# useful for easily allocating distributed data storages (fields)\n",
-    "quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)"
+    "quantity_factory = QuantityFactory(sizer=sizer, backend=backend)"
    ]
   },
   {

--- a/pace/driver.py
+++ b/pace/driver.py
@@ -177,7 +177,7 @@ class DriverConfig:
                 tile_partitioner=communicator.partitioner.tile,
                 tile_rank=communicator.tile.rank,
             )
-            quantity_factory = QuantityFactory.from_backend(
+            quantity_factory = QuantityFactory(
                 sizer, backend=self.stencil_config.compilation_config.backend
             )
 
@@ -207,7 +207,7 @@ class DriverConfig:
                 tile_rank=communicator.tile.rank,
             )
             if quantity_factory is None:
-                quantity_factory = QuantityFactory.from_backend(
+                quantity_factory = QuantityFactory(
                     sizer, backend=self.stencil_config.compilation_config.backend
                 )
             if stencil_factory is None:
@@ -760,7 +760,7 @@ def _setup_factories(
     grid_indexing = GridIndexing.from_sizer_and_communicator(
         sizer=sizer, comm=communicator
     )
-    quantity_factory = QuantityFactory.from_backend(
+    quantity_factory = QuantityFactory(
         sizer, backend=config.stencil_config.compilation_config.backend
     )
     stencil_factory = StencilFactory(

--- a/pace/state.py
+++ b/pace/state.py
@@ -91,7 +91,7 @@ class DriverState:
             tile_partitioner=communicator.partitioner.tile,
             tile_rank=communicator.tile.rank,
         )
-        quantity_factory = QuantityFactory.from_backend(
+        quantity_factory = QuantityFactory(
             sizer, backend=driver_config.stencil_config.compilation_config.backend
         )
 

--- a/tests/main/driver/test_diagnostics_config.py
+++ b/tests/main/driver/test_diagnostics_config.py
@@ -42,7 +42,7 @@ def test_zselect_raises_error_if_not_3d(tmpdir):
             z_select=[ZSelect(level=0, names=["phis"])],
         )
         result = config.diagnostics_factory(unittest.mock.MagicMock())
-        quantity_factory = QuantityFactory.from_backend(
+        quantity_factory = QuantityFactory(
             sizer=SubtileGridSizer.from_tile_params(
                 nx_tile=12,
                 ny_tile=12,
@@ -63,7 +63,7 @@ def test_zselect_raises_error_if_3rd_dim_not_z(tmpdir):
             z_select=[ZSelect(level=0, names=["foo"])],
         )
         result = config.diagnostics_factory(unittest.mock.MagicMock())
-        quantity_factory = QuantityFactory.from_backend(
+        quantity_factory = QuantityFactory(
             sizer=SubtileGridSizer.from_tile_params(
                 nx_tile=12,
                 ny_tile=12,

--- a/tests/main/driver/test_restart_fortran.py
+++ b/tests/main/driver/test_restart_fortran.py
@@ -35,7 +35,7 @@ def test_state_from_fortran_restart():
         tile_rank=0,
     )
 
-    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend="numpy")
+    quantity_factory = QuantityFactory(sizer=sizer, backend="numpy")
     restart_dir = REPO_ROOT / "tests" / "main" / "data" / "c12_restart"
 
     (

--- a/tests/main/driver/test_restart_serial.py
+++ b/tests/main/driver/test_restart_serial.py
@@ -67,7 +67,7 @@ def test_restart_save_to_disk():
             tile_partitioner=partitioner.tile,
             tile_rank=communicator.tile.rank,
         )
-        quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+        quantity_factory = QuantityFactory(sizer=sizer, backend=backend)
 
         eta_file = Path(driver_config.grid_config.config.eta_file)
         (

--- a/tests/main/fv3core/test_dycore_baroclinic.py
+++ b/tests/main/fv3core/test_dycore_baroclinic.py
@@ -112,7 +112,7 @@ def setup_dycore(
     grid_indexing = GridIndexing.from_sizer_and_communicator(
         sizer=sizer, comm=communicator
     )
-    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+    quantity_factory = QuantityFactory(sizer=sizer, backend=backend)
     eta_file = "NDSL/tests/data/eta/eta79.nc"
     metric_terms = MetricTerms(
         quantity_factory=quantity_factory,

--- a/tests/main/fv3core/test_dycore_call.py
+++ b/tests/main/fv3core/test_dycore_call.py
@@ -96,7 +96,7 @@ def setup_dycore() -> Tuple[DynamicalCore, DycoreState, Timer]:
     grid_indexing = GridIndexing.from_sizer_and_communicator(
         sizer=sizer, comm=communicator
     )
-    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+    quantity_factory = QuantityFactory(sizer=sizer, backend=backend)
     eta_file = Path("NDSL/tests/data/eta/eta79.nc")
     metric_terms = MetricTerms(
         quantity_factory=quantity_factory,

--- a/tests/main/physics/test_integration.py
+++ b/tests/main/physics/test_integration.py
@@ -50,7 +50,7 @@ def setup_physics():
     grid_indexing = GridIndexing.from_sizer_and_communicator(
         sizer=sizer, comm=communicator
     )
-    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+    quantity_factory = QuantityFactory(sizer=sizer, backend=backend)
     dace_config = DaceConfig(
         communicator=communicator,
         backend=backend,

--- a/tests/main/test_grid_init.py
+++ b/tests/main/test_grid_init.py
@@ -25,7 +25,7 @@ def get_cube_comm(layout, rank: int):
 def get_quantity_factory(layout, nx_tile, ny_tile, nz):
     nx = nx_tile // layout[0]
     ny = ny_tile // layout[1]
-    return QuantityFactory.from_backend(
+    return QuantityFactory(
         sizer=SubtileGridSizer.from_tile_params(
             nx_tile=nx,
             ny_tile=ny,

--- a/tests/mpi/test_grid_init.py
+++ b/tests/mpi/test_grid_init.py
@@ -27,7 +27,7 @@ def get_cube_comm(layout, comm: MPIComm):
 def get_quantity_factory(layout, nx_tile, ny_tile, nz):
     nx = nx_tile // layout[0]
     ny = ny_tile // layout[1]
-    return QuantityFactory.from_backend(
+    return QuantityFactory(
         sizer=SubtileGridSizer.from_tile_params(
             nx=nx, ny=ny, nz=nz, n_halo=3, layout=(1, 1)
         ),

--- a/tests/savepoint/translate/translate_driver.py
+++ b/tests/savepoint/translate/translate_driver.py
@@ -36,7 +36,7 @@ class TranslateDriver(TranslateFVDynamics):
             tile_rank=communicator.tile.rank,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
+        quantity_factory = QuantityFactory(
             sizer, backend=self.stencil_config.compilation_config.backend
         )
         physics_state = PhysicsState.init_zeros(


### PR DESCRIPTION
**Description**

Prefer the new constructor of `QuantityFactor` over the deprecated call to `QuantityFactor.from_backend(...)`. This removes a bunch of deprecation warnings in tests.

See https://github.com/NOAA-GFDL/NDSL/pull/228 for context.

/cc @FlorianDeconinck

**How Has This Been Tested?**

Search and manual replace of `from_backend` within pace. CI is still green. The remaining deprecation warnings in tests come from pyFV3 and pySHiELD. PRs in these repos are coming up shortly. Once they are merge, we can update the submodules and the CI output should be significantly shorter again :wink: 

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
