### PR TITLE
refactor: update GitHub workflow dependencies

### DIFF
--- a/.github/workflows/container_build_test.yaml
+++ b/.github/workflows/container_build_test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Files
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build Dockerfile

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
       - name: Step Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       # Only restore (don't save) caches on PRs. New caches created from PRs won't be
       # accessible from other PRs, see workflows/create-cache.yaml.
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit_${{ env.pythonLocation }}_${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: "External trigger: Checkout pace/develop"
         if: ${{ inputs.component_trigger }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
           repository: NOAA-GFDL/pace
@@ -40,7 +40,7 @@ jobs:
           ref: develop
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -59,7 +59,7 @@ jobs:
         run: rm -rf ${GITHUB_WORKSPACE}/pace/${{inputs.component_name}}
 
       - name: Checkout out hash that triggered CI
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
           path: pace/${{inputs.component_name}}


### PR DESCRIPTION
**Description**
This PR updates our GitHub workflows to use actions/checkout@v6, actions/setup-python@v6, and actions/cache@v5. Changes are minimal, but require a new minimal GHA runner version, which forces the major version bumps.

**How Has This Been Tested?**
Using currently implemented CI

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
