### PR TITLE
Update NDSL to 2026.01.00

### DIFF
--- a/pace/diagnostics.py
+++ b/pace/diagnostics.py
@@ -58,6 +58,7 @@ class ZSelect:
                 origin=getattr(state, name).origin[0:2],
                 extent=getattr(state, name).extent[0:2],
                 units=getattr(state, name).units,
+                backend=getattr(state, name).backend,
             )
         return output
 
@@ -235,7 +236,7 @@ class NullDiagnostics(Diagnostics):
         pass
 
 
-def _compute_column_integral(name: str, q_in: Quantity, delp: Quantity):
+def _compute_column_integral(name: str, q_in: Quantity, delp: Quantity) -> Quantity:
     """
     Compute column integrated mixing ratio (e.g., total liquid water path)
 
@@ -243,19 +244,25 @@ def _compute_column_integral(name: str, q_in: Quantity, delp: Quantity):
         name: name of the tracer
         q_in: tracer mixing ratio
         delp: pressure thickness of atmospheric layer
+
+    Returns:
+        The column integral.
     """
-    assert len(q_in.dims) > 2
+    if len(q_in.dims) <= 2:
+        raise RuntimeError("This function assumes that q_in is at least 3-dimensional.")
+
     if q_in.dims[2] != Z_DIM:
-        raise NotImplementedError(
-            "this function assumes the z-dimension is the third dimension"
+        raise RuntimeError(
+            "This function assumes the z-dimension is the third dimension"
         )
+
     k_slice = slice(q_in.origin[2], q_in.origin[2] + q_in.extent[2])
-    column_integral = Quantity(
+    return Quantity(
         RGRAV
         * q_in.np.sum(q_in.data[:, :, k_slice] * delp.data[:, :, k_slice], axis=2),
         dims=tuple(q_in.dims[:2]) + tuple(q_in.dims[3:]),
         origin=q_in.metadata.origin[0:2],
         extent=(q_in.metadata.extent[0], q_in.metadata.extent[1]),
         units="kg/m**2",
+        backend=q_in.backend,
     )
-    return column_integral


### PR DESCRIPTION
**Description**

This PR updates the NDSL submodule to NDSL version 2026.01.00, which was released yesterday.

Once this PR is merged, we can start to work on the 2026.01.00 deprecations, e.g. this PR is necessary for

- https://github.com/NOAA-GFDL/PyFV3/pull/117
- and https://github.com/NOAA-GFDL/PySHiELD/pull/83

to proceed.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
  New warnings show up due to new deprecations in NDSL
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
