### PR TITLE
[Config | Dace] Remove `DaCeConfig` from restart

### DIFF
--- a/pace/driver.py
+++ b/pace/driver.py
@@ -588,7 +588,7 @@ class Driver:
         self.config.stencil_config.dace_config = DaceConfig(
             communicator=communicator,
             backend=self.config.stencil_config.backend,
-            orchestration=None
+            orchestration=None,
         )
 
     @dace_inhibitor

--- a/pace/driver.py
+++ b/pace/driver.py
@@ -305,10 +305,6 @@ class DriverConfig:
         restart_path: str,
     ):
         config_dict = dataclasses.asdict(self)
-        if self.stencil_config.dace_config:
-            config_dict["stencil_config"][
-                "dace_config"
-            ] = self.stencil_config.dace_config.as_dict()
         config_dict["stencil_config"][
             "compilation_config"
         ] = self.stencil_config.compilation_config.as_dict()
@@ -331,6 +327,10 @@ class DriverConfig:
         # restart config doesn't have 'case'
         if "case" in config_dict["initialization"]["config"].keys():
             del config_dict["initialization"]["config"]["case"]
+        # remove dace config - it will be init from other piece of the config
+        # during Driver.__init__
+        config_dict["stencil_config"].pop("dace_config", None)
+
         with open(f"{restart_path}/restart.yaml", "w") as file:
             yaml.safe_dump(config_dict, file)
 

--- a/pace/driver.py
+++ b/pace/driver.py
@@ -287,13 +287,6 @@ class DriverConfig:
 
         if (
             isinstance(kwargs["stencil_config"], dict)
-            and "dace_config" in kwargs["stencil_config"].keys()
-        ):
-            kwargs["stencil_config"]["dace_config"] = DaceConfig.from_dict(
-                data=kwargs["stencil_config"]["dace_config"]
-            )
-        if (
-            isinstance(kwargs["stencil_config"], dict)
             and "compilation_config" in kwargs["stencil_config"].keys()
         ):
             kwargs["stencil_config"]["compilation_config"] = (
@@ -592,6 +585,11 @@ class Driver:
             communicator=communicator,
         )
         self.config.stencil_config.compilation_config = compilation_config
+        self.config.stencil_config.dace_config = DaceConfig(
+            communicator=communicator,
+            backend=self.config.stencil_config.backend,
+            orchestration=None
+        )
 
     @dace_inhibitor
     def _callback_diagnostics(self):


### PR DESCRIPTION
The current status of the configuration for orchestration is very fragile. This PR comes after a bad change on the default [fixed here](https://github.com/NOAA-GFDL/NDSL/pull/408). We will now force the usage of `FV3_DACEMODE` by reseting the DaceConfig when we have the Communicator ready. 

Details:
- Remove `DaceConfig` via dict (unusuable)
- Use the deffered initialization to push a DaceConfig which is controlled by FV3_DACEMODE

**How Has This Been Tested?**

Ran orchestrated c12 from config

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
