### PR TITLE
Adding cron job for BuildAndRun of baroclinic_c12_orch_cpu config every Sunday

### DIFF
--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -1,0 +1,37 @@
+on:
+  schedule:
+    - cron: '0 0 * * 0' # sundays @ midnight
+
+jobs:
+  pace_orch_build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    env:
+      python_default: '3.12'
+
+    steps:
+      - name: Checkout Files
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: 'Setup Python ${{ env.python_default }}'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.python_default }}
+
+      - name: Install mpi (MPICH flavor)
+        run: pip install mpich
+
+      - name: Install packages
+        run: |
+          cd ${GITHUB_WORKSPACE}/pace
+          pip install .
+
+      - name: Build and Run baroclinic test case
+        run: |
+          cd ${GITHUB_WORKSPACE}/pace
+          export FV3_DACEMODE=BuildAndRun
+          mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c12_orch_cpu.yaml


### PR DESCRIPTION
**Description**
This PR introduces a workflow for running a cron job of a `BuildAndRun` of the `baroclinic_c12_orch_cpu.yaml` configuration to tests DaCe orchestration over a model run.

Currently this is expected to fail as we are debugging issues within orchestration.


**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
