### PR TITLE
use modern type hints in pace

### DIFF
--- a/pace/__init__.py
+++ b/pace/__init__.py
@@ -1,5 +1,3 @@
-from ndsl.performance import PerformanceConfig
-
 from .comm import (
     CreatesComm,
     CreatesCommSelector,

--- a/pace/comm.py
+++ b/pace/comm.py
@@ -2,7 +2,7 @@ import abc
 import copy
 import dataclasses
 import os
-from typing import Any, ClassVar, List, Mapping, TypeVar, cast
+from typing import Any, ClassVar, Mapping, TypeVar, cast
 
 from ndsl import MPIComm
 from ndsl.comm import (
@@ -245,7 +245,7 @@ class WriterCommConfig(CreatesComm):
         path: directory to write data to
     """
 
-    ranks: List[int]
+    ranks: list[int]
     path: str = "."
 
     def get_comm(self) -> CachingCommWriter:

--- a/pace/driver.py
+++ b/pace/driver.py
@@ -3,7 +3,7 @@ import functools
 import warnings
 from datetime import datetime, timedelta
 from math import floor
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import dace
 import dacite
@@ -95,9 +95,9 @@ class DriverConfig:
     initialization: InitializerSelector
     nx_tile: int
     nz: int
-    layout: Tuple[int, int]
+    layout: tuple[int, int]
     dt_atmos: float
-    grid_type: Optional[int] = 0
+    grid_type: int | None = 0
     grid_config: GridInitializerSelector = dataclasses.field(
         default_factory=lambda: GridInitializerSelector(
             type="generated", config=GeneratedGridConfig()
@@ -129,14 +129,14 @@ class DriverConfig:
     pair_debug: bool = False
     output_initial_state: bool = False
     output_frequency: int = 1
-    safety_check_frequency: Optional[int] = None
+    safety_check_frequency: int | None = None
 
     @functools.cached_property
     def timestep(self) -> timedelta:
         return timedelta(seconds=self.dt_atmos)
 
     @property
-    def start_time(self) -> Union[datetime, timedelta]:
+    def start_time(self) -> datetime | timedelta:
         return self.initialization.start_time
 
     @functools.cached_property
@@ -166,8 +166,8 @@ class DriverConfig:
     def get_grid(
         self,
         communicator: Communicator,
-        quantity_factory: Optional[QuantityFactory] = None,
-    ) -> Tuple[DampingCoefficients, DriverGridData, GridData]:
+        quantity_factory: QuantityFactory | None = None,
+    ) -> tuple[DampingCoefficients, DriverGridData, GridData]:
         if quantity_factory is None:
             sizer = SubtileGridSizer.from_tile_params(
                 nx_tile=self.nx_tile,
@@ -194,8 +194,8 @@ class DriverConfig:
         damping_coefficients: DampingCoefficients,
         driver_grid_data: DriverGridData,
         grid_data: GridData,
-        quantity_factory: Optional[QuantityFactory] = None,
-        stencil_factory: Optional[StencilFactory] = None,
+        quantity_factory: QuantityFactory | None = None,
+        stencil_factory: StencilFactory | None = None,
     ) -> DriverState:
         """Load the initial state of the driver."""
         if quantity_factory is None or stencil_factory is None:
@@ -231,7 +231,7 @@ class DriverConfig:
         )
 
     @classmethod
-    def from_dict(cls, kwargs: Dict[str, Any]) -> "DriverConfig":
+    def from_dict(cls, kwargs: dict[str, Any]) -> "DriverConfig":
         if isinstance(kwargs["dycore_config"], dict):
             for derived_name in ("dt_atmos", "layout", "npx", "npy", "npz", "ntiles"):
                 if derived_name in kwargs["dycore_config"]:
@@ -301,7 +301,7 @@ class DriverConfig:
 
     def write_for_restart(
         self,
-        time: Union[datetime, timedelta],
+        time: datetime | timedelta,
         restart_path: str,
     ):
         config_dict = dataclasses.asdict(self)
@@ -338,7 +338,7 @@ class DriverConfig:
 @dataclasses.dataclass()
 class RestartConfig:
     save_restart: bool = False
-    intermediate_restart: List[int] = dataclasses.field(default_factory=list)
+    intermediate_restart: list[int] = dataclasses.field(default_factory=list)
     save_intermediate_restart: bool = False
 
     def __post_init__(self):
@@ -368,7 +368,7 @@ class RestartConfig:
         *,
         step: int,
         comm: Comm,
-        time: Union[datetime, timedelta],
+        time: datetime | timedelta,
         driver_config: DriverConfig,
         restart_path: str,
     ):
@@ -734,7 +734,7 @@ def _setup_factories(
     config: DriverConfig,
     communicator: Communicator,
     stencil_compare_comm,
-) -> Tuple[QuantityFactory, StencilFactory]:
+) -> tuple[QuantityFactory, StencilFactory]:
     """
     Args:
         config: configuration of driver

--- a/pace/grid.py
+++ b/pace/grid.py
@@ -9,7 +9,7 @@ import xarray as xr
 from ndsl import QuantityFactory, ndsl_log
 from ndsl.comm.partitioner import get_tile_index
 from ndsl.config import Backend
-from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM
+from ndsl.constants import I_INTERFACE_DIM, J_INTERFACE_DIM
 from ndsl.grid import (
     AngleGridData,
     ContravariantGridData,

--- a/pace/initialization.py
+++ b/pace/initialization.py
@@ -16,7 +16,6 @@ from ndsl import (
     StencilFactory,
 )
 from ndsl.config import Backend
-from ndsl.constants import I_DIM, J_DIM
 from ndsl.grid import DampingCoefficients, DriverGridData, GridData
 from ndsl.stencils.testing import TranslateGrid, grid
 from ndsl.typing import Communicator

--- a/pace/initialization.py
+++ b/pace/initialization.py
@@ -3,7 +3,7 @@ import dataclasses
 import os
 import pathlib
 from datetime import datetime
-from typing import Callable, ClassVar, List, Type, TypeVar
+from typing import Callable, ClassVar, TypeVar
 
 import f90nml
 
@@ -41,11 +41,11 @@ class Initializer(abc.ABC):
         damping_coefficients: DampingCoefficients,
         driver_grid_data: DriverGridData,
         grid_data: GridData,
-        schemes: List[PHYSICS_PACKAGES],
+        schemes: list[PHYSICS_PACKAGES],
     ) -> DriverState: ...
 
 
-IT = TypeVar("IT", bound=Type[Initializer])
+IT = TypeVar("IT", bound=type[Initializer])
 
 
 @dataclasses.dataclass
@@ -78,7 +78,7 @@ class InitializerSelector(Initializer):
         damping_coefficients: DampingCoefficients,
         driver_grid_data: DriverGridData,
         grid_data: GridData,
-        schemes: List[PHYSICS_PACKAGES],
+        schemes: list[PHYSICS_PACKAGES],
     ) -> DriverState:
         return self.config.get_driver_state(
             quantity_factory=quantity_factory,
@@ -117,7 +117,7 @@ class AnalyticInit(Initializer):
         damping_coefficients: DampingCoefficients,
         driver_grid_data: DriverGridData,
         grid_data: GridData,
-        schemes: List[PHYSICS_PACKAGES],
+        schemes: list[PHYSICS_PACKAGES],
     ) -> DriverState:
         dycore_state = analytic_init.init_analytic_state(
             analytic_init_case=self.case,
@@ -162,7 +162,7 @@ class RestartInit(Initializer):
         damping_coefficients: DampingCoefficients,
         driver_grid_data: DriverGridData,
         grid_data: GridData,
-        schemes: List[PHYSICS_PACKAGES],
+        schemes: list[PHYSICS_PACKAGES],
     ) -> DriverState:
         state = _restart_driver_state(
             self.path,
@@ -213,7 +213,7 @@ class FortranRestartInit(Initializer):
         damping_coefficients: DampingCoefficients,
         driver_grid_data: DriverGridData,
         grid_data: GridData,
-        schemes: List[PHYSICS_PACKAGES],
+        schemes: list[PHYSICS_PACKAGES],
     ) -> DriverState:
         state = _restart_driver_state(
             self.path,
@@ -286,7 +286,7 @@ class SerialboxInit(Initializer):
         damping_coefficients: DampingCoefficients,
         driver_grid_data: DriverGridData,
         grid_data: GridData,
-        schemes: List[PHYSICS_PACKAGES],
+        schemes: list[PHYSICS_PACKAGES],
     ) -> DriverState:
         dycore_state = self._initialize_dycore_state(
             communicator, quantity_factory.backend
@@ -364,7 +364,7 @@ class PredefinedStateInit(Initializer):
         damping_coefficients: DampingCoefficients,
         driver_grid_data: DriverGridData,
         grid_data: GridData,
-        schemes: List[PHYSICS_PACKAGES],
+        schemes: list[PHYSICS_PACKAGES],
     ) -> DriverState:
         return DriverState(
             dycore_state=self.dycore_state,

--- a/pace/registry.py
+++ b/pace/registry.py
@@ -1,11 +1,11 @@
 import dataclasses
-from typing import Callable, Dict, Generic, Optional, Type, TypeVar
+from typing import Callable, Generic, TypeVar
 
 import dacite
 
 
 T = TypeVar("T")
-TT = TypeVar("TT", bound=Type)
+TT = TypeVar("TT", bound=type)
 
 
 @dataclasses.dataclass
@@ -74,7 +74,7 @@ class Registry(Generic[T]):
         certain values and store them.
     """
 
-    def __init__(self, default_type: Optional[str] = None):
+    def __init__(self, default_type: str | None = None):
         """
         Initialize the registry.
 
@@ -82,7 +82,7 @@ class Registry(Generic[T]):
             default_type: if given, the "type" key in the config dict is optional
                 and by default this type will be used.
         """
-        self._types: Dict[str, Type[T]] = {}
+        self._types: dict[str, type[T]] = {}
         self.default_type = default_type
 
     def register(self, type_name: str) -> Callable[[TT], TT]:

--- a/pace/run.py
+++ b/pace/run.py
@@ -1,6 +1,5 @@
 import dataclasses
 import gc
-from typing import Optional
 
 import click
 import yaml
@@ -16,16 +15,11 @@ from pace.driver import Driver, DriverConfig
     type=click.Path(exists=True, readable=True, dir_okay=False, resolve_path=True),
 )
 @click.option(
-    "--log-rank",
-    type=click.INT,
-    help="rank to log from, or all ranks by default, ignored if running without MPI",
-)
-@click.option(
     "--log-level",
     default="info",
     help="one of 'debug', 'info', 'warning', 'error', 'critical'",
 )
-def command_line(config_path: str, log_rank: Optional[int], log_level: str):
+def command_line(config_path: str, log_level: str) -> None:
     """
     Run the driver.
 
@@ -43,13 +37,12 @@ def command_line(config_path: str, log_rank: Optional[int], log_level: str):
     main(driver_config=driver_config)
 
 
-def main(driver_config: DriverConfig) -> Driver:
+def main(driver_config: DriverConfig) -> None:
     driver = Driver(config=driver_config)
     try:
         driver.step_all()
     finally:
         driver.cleanup()
-    return driver
 
 
 if __name__ == "__main__":

--- a/pace/safety_checks.py
+++ b/pace/safety_checks.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Dict, Optional
+from typing import ClassVar
 
 import numpy as np
 
@@ -9,8 +9,8 @@ from pyfv3 import DycoreState
 class VariableBounds:
     def __init__(
         self,
-        minimum_value: Optional[float] = None,
-        maximum_value: Optional[float] = None,
+        minimum_value: float | None = None,
+        maximum_value: float | None = None,
         compute_domain_only: bool = False,
     ) -> None:
         self.minimum_value = minimum_value
@@ -27,23 +27,23 @@ class SafetyChecker:
         RuntimeError: Variables outside the specified bounds
     """
 
-    checks: ClassVar[Dict[str, VariableBounds]] = {}
+    checks: ClassVar[dict[str, VariableBounds]] = {}
 
     @classmethod
     def register_variable(
         cls,
         name: str,
-        minimum_value: Optional[float] = None,
-        maximum_value: Optional[float] = None,
+        minimum_value: float | None = None,
+        maximum_value: float | None = None,
         compute_domain_only: bool = False,
     ):
         """Register a variable in the checker
 
         Args:
             name (str): name of the variable in the dycore state
-            minimum_value (Optional[float], optional): Minimum value if specified.
+            minimum_value (float | None, optional): Minimum value if specified.
                 Defaults to None.
-            maximum_value (Optional[float], optional): Maximum value if specified.
+            maximum_value (float | None, optional): Maximum value if specified.
                 Defaults to None.
             compute_domain_only (bool, optional): If evaluation should only happen
                 on the compute or the entire domain. Defaults to False.


### PR DESCRIPTION
**Description**

Type hints for containers like lists and dictionaries became generic in python 3.9. In recent python versions, it is thus not necessary anymore to import e.g. `List` from `typing`. 

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
