### PR TITLE
ci: named GHA workflows

### DIFF
--- a/.github/workflows/container_build_test.yaml
+++ b/.github/workflows/container_build_test.yaml
@@ -1,9 +1,11 @@
+name: "Container Build"
+
 on:
   push:
     branches:
       - 'develop'
   schedule:
-    - cron: '0 0 * * 0' # sundays @ midnight
+    - cron: '0 0 * * 0' # Sundays @ midnight
 
 jobs:
   test-container-builds:
@@ -14,7 +16,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build Dockerfile
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: false

--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -1,6 +1,8 @@
+name: "Orchestrated model run"
+
 on:
   schedule:
-    - cron: '0 0 * * 0' # sundays @ midnight
+    - cron: '0 0 * * 0' # Sundays @ midnight
 
 jobs:
   pace_orch_build:
@@ -30,7 +32,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/pace
           pip install .
 
-      - name: Build and Run baroclinic test case
+      - name: Build and run baroclinic test case
         run: |
           cd ${GITHUB_WORKSPACE}/pace
           export FV3_DACEMODE=BuildAndRun


### PR DESCRIPTION
**Description**

GitHub Actions workflows can have names. These names for example show up in the 'Actions' tab on the left, where you can filter by workflow.

This PR adds names for the container build workflow and for the new regular orchestrated model runs.

The PR also updates `docker/build-push-action` from `v6` to `v7` to make it compatible with the upcoming node24 GHA runners.

**How Has This Been Tested?**

By code self-review.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
