### PR TITLE
ci: fix orchestrated model run

### DIFF
--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -56,5 +56,4 @@ jobs:
         env:
           FV3_DACEMODE: BuildAndRun
           NDSL_LOGLEVEL: Info
-        run: |
-          mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c12_orch_cpu.yaml
+        run: mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c12_orch_cpu.yaml

--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -7,7 +7,7 @@ on:
   # Temporarily uncomment the next line in case you want to run this workflow on you PR.
   # For example, this can be useful when you are changing the workflow and you don't
   # want to wait until Sunday to see it run.
-  pull_request:
+  # pull_request:
 
 jobs:
   pace_orch_build:

--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -15,10 +15,27 @@ jobs:
       python_default: '3.12'
 
     steps:
-      - name: Checkout Files
+      - name: Checkout pace
+        uses: actions/checkout@v6
+
+      - name: Checkout NDSL
         uses: actions/checkout@v6
         with:
+          repository: NOAA-GFDL/NDSL
+          path: NDSL
           submodules: recursive
+
+      - name: Checkout pyFV3
+        uses: actions/checkout@v6
+        with:
+          repository: NOAA-GFDL/pyFV3
+          path: pyFV3
+
+      - name: Checkout pySHiELD
+        uses: actions/checkout@v6
+        with:
+          repository: NOAA-GFDL/pySHiELD
+          path: pySHiELD
 
       - name: 'Setup Python ${{ env.python_default }}'
         uses: actions/setup-python@v6
@@ -32,6 +49,7 @@ jobs:
         run: pip install .
 
       - name: Build and run baroclinic test case
+        env:
+          FV3_DACEMODE: BuildAndRun
         run: |
-          export FV3_DACEMODE=BuildAndRun
           mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c12_orch_cpu.yaml

--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -51,5 +51,6 @@ jobs:
       - name: Build and run baroclinic test case
         env:
           FV3_DACEMODE: BuildAndRun
+          NDSL_LOGLEVEL: Debug
         run: |
           mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c12_orch_cpu.yaml

--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -3,11 +3,14 @@ name: "Orchestrated model run"
 on:
   schedule:
     - cron: '0 0 * * 0' # Sundays @ midnight
-  pull_request: # testing only
+  # Temporarily uncomment the next line in case you want to run this workflow on you PR.
+  # For example, this can be useful when you are changing the workflow and you don't
+  # want to wait until Sunday to see it run.
+  # pull_request:
 
 jobs:
   pace_orch_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -1,12 +1,13 @@
 name: "Orchestrated model run"
 
 on:
+  # Sundays @ midnight
   schedule:
-    - cron: '0 0 * * 0' # Sundays @ midnight
+    - cron: '0 0 * * 0'
   # Temporarily uncomment the next line in case you want to run this workflow on you PR.
   # For example, this can be useful when you are changing the workflow and you don't
   # want to wait until Sunday to see it run.
-  # pull_request:
+  pull_request:
 
 jobs:
   pace_orch_build:
@@ -54,6 +55,6 @@ jobs:
       - name: Build and run baroclinic test case
         env:
           FV3_DACEMODE: BuildAndRun
-          NDSL_LOGLEVEL: Debug
+          NDSL_LOGLEVEL: Info
         run: |
           mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c12_orch_cpu.yaml

--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -3,6 +3,7 @@ name: "Orchestrated model run"
 on:
   schedule:
     - cron: '0 0 * * 0' # Sundays @ midnight
+  pull_request: # testing only
 
 jobs:
   pace_orch_build:
@@ -28,12 +29,9 @@ jobs:
         run: pip install mpich
 
       - name: Install packages
-        run: |
-          cd ${GITHUB_WORKSPACE}/pace
-          pip install .
+        run: pip install .
 
       - name: Build and run baroclinic test case
         run: |
-          cd ${GITHUB_WORKSPACE}/pace
           export FV3_DACEMODE=BuildAndRun
           mpiexec -np 6 python -m pace.run examples/configs/baroclinic_c12_orch_cpu.yaml

--- a/examples/configs/baroclinic_c12_orch_cpu.yaml
+++ b/examples/configs/baroclinic_c12_orch_cpu.yaml
@@ -1,6 +1,6 @@
 stencil_config:
   compilation_config:
-    backend: st:dace:cpu:KIJ
+    backend: orch:dace:cpu:KIJ
     rebuild: false
     validate_args: true
     format_source: false


### PR DESCRIPTION
**Description**

This PR fixes the workflow to run an orchestrated model run on Sunday night. The PR does the following three things:

1. Fix a path configuration issue such that `pip install .` is not already failing
2. Checkout the latest `develop` versions of submodules (`NDSL/`, `pyFV3/`, and `pySHiELD`)
3. Fix the configuration such that we actually use the orchestrated backend (otherwise, we don't run in orchestration mode)

This is a follow-up from #186, which failed it's first regular run [see here](https://github.com/NOAA-GFDL/pace/actions/runs/24946587501/job/73048973283) because it couldn't even install `pace` and thus failed before even running the test case.

TODO

- [x] discuss if we want to run with latest develop versions of `NDSL`, `pyFV3`, and `pySHiELD`
- [x] figure out why we aren't actually orchestrating
- [x] remove `on: pull_request` hook

**How Has This Been Tested?**

Tested by actually running the workflow (to be reverted) as part of the pull request.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
  N/A
