### PR TITLE
ci: update `actions/checkout` v6 -> v7

### DIFF
--- a/.github/workflows/container_build_test.yaml
+++ b/.github/workflows/container_build_test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Files
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Build Dockerfile

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python 3.12
         uses: actions/setup-python@v6

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/main_unit_tests.yaml
+++ b/.github/workflows/main_unit_tests.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: "External trigger: Checkout pace/develop"
         if: ${{ inputs.component_name }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           repository: NOAA-GFDL/pace
@@ -58,7 +58,7 @@ jobs:
         run: rm -rf ${GITHUB_WORKSPACE}/pace/${{inputs.component_name}}
 
       - name: Checkout out hash that triggered CI
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           path: pace/${{inputs.component_name}}

--- a/.github/workflows/orch_build_test.yaml
+++ b/.github/workflows/orch_build_test.yaml
@@ -20,23 +20,23 @@ jobs:
 
     steps:
       - name: Checkout pace
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout NDSL
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: NOAA-GFDL/NDSL
           path: NDSL
           submodules: recursive
 
       - name: Checkout pyFV3
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: NOAA-GFDL/pyFV3
           path: pyFV3
 
       - name: Checkout pySHiELD
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: NOAA-GFDL/pySHiELD
           path: pySHiELD


### PR DESCRIPTION
**Description**

This PR updates `actions/checkout` from `v6` to the latest `v7`. No breakage is expected from reading the change log.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N7A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
