### PR TITLE
Updating `NullComm` to support boundary condition ingest methods in `NDSL`

### DIFF
--- a/pace/comm.py
+++ b/pace/comm.py
@@ -119,6 +119,9 @@ class NullComm(Comm[T]):
 
     def Allreduce_inplace(self, obj: T, op: ReductionOperator) -> T:
         raise NotImplementedError("NullComm.Allreduce_inplace")
+    
+    def Scatterv(self, sendbuf, recvbuf, root: int = 0, **kwargs: dict):  # type: ignore[no-untyped-def]
+        pass
 
 
 class CreatesComm(abc.ABC):

--- a/pace/comm.py
+++ b/pace/comm.py
@@ -119,7 +119,7 @@ class NullComm(Comm[T]):
 
     def Allreduce_inplace(self, obj: T, op: ReductionOperator) -> T:
         raise NotImplementedError("NullComm.Allreduce_inplace")
-    
+
     def Scatterv(self, sendbuf, recvbuf, root: int = 0, **kwargs: dict):  # type: ignore[no-untyped-def]
         pass
 


### PR DESCRIPTION
**Description**
This PR introduces a method to `NullComm` to support the introduction of the `Scatterv` method used for boundary condition ingest in `NDSL`

**How Has This Been Tested?**
Current CI

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
