### PR TITLE
feat(driver): add years and months support to DriverConfig total_time (fixes #197)

### DIFF
--- a/pace/driver.py
+++ b/pace/driver.py
@@ -70,6 +70,8 @@ class DriverConfig:
         diagnostics_config: configuration for output diagnostics
         dycore_config: configuration for dynamical core
         physics_config: configuration for physics
+        years: years to add to total simulation time (365 days per year)
+        months: months to add to total simulation time (30 days per month)
         days: days to add to total simulation time
         hours: hours to add to total simulation time
         minutes: minutes to add to total simulation time
@@ -118,6 +120,8 @@ class DriverConfig:
     )
     physics_config: PhysicsConfig = dataclasses.field(default_factory=PhysicsConfig)
 
+    years: int = 0
+    months: int = 0
     days: int = 0
     hours: int = 0
     minutes: int = 0
@@ -142,8 +146,9 @@ class DriverConfig:
 
     @functools.cached_property
     def total_time(self) -> timedelta:
+        total_days = self.days + self.years * 365 + self.months * 30
         return timedelta(
-            days=self.days, hours=self.hours, minutes=self.minutes, seconds=self.seconds
+            days=total_days, hours=self.hours, minutes=self.minutes, seconds=self.seconds
         )
 
     def n_timesteps(self) -> int:

--- a/tests/main/driver/test_driver.py
+++ b/tests/main/driver/test_driver.py
@@ -18,6 +18,8 @@ def get_driver_config(
     nx_tile: int = 12,
     nz: int = 79,
     dt_atmos: int = 450,
+    years: int = 0,
+    months: int = 0,
     days: int = 0,
     hours: int = 0,
     minutes: int = 0,
@@ -37,6 +39,8 @@ def get_driver_config(
         nx_tile=nx_tile,
         nz=nz,
         dt_atmos=dt_atmos,
+        years=years,
+        months=months,
         days=days,
         hours=hours,
         minutes=minutes,
@@ -57,19 +61,23 @@ def get_driver_config(
 
 
 @pytest.mark.parametrize(
-    "days, hours, minutes, seconds, expected",
+    "years, months, days, hours, minutes, seconds, expected",
     [
-        pytest.param(1, 0, 0, 0, timedelta(days=1), id="day"),
-        pytest.param(0, 1, 0, 0, timedelta(hours=1), id="hour"),
-        pytest.param(0, 0, 1, 0, timedelta(minutes=1), id="minute"),
-        pytest.param(0, 0, 0, 1, timedelta(seconds=1), id="second"),
+        pytest.param(1, 0, 0, 0, 0, 0, timedelta(days=365), id="year"),
+        pytest.param(0, 1, 0, 0, 0, 0, timedelta(days=30), id="month"),
+        pytest.param(0, 0, 1, 0, 0, 0, timedelta(days=1), id="day"),
+        pytest.param(0, 0, 0, 1, 0, 0, timedelta(hours=1), id="hour"),
+        pytest.param(0, 0, 0, 0, 1, 0, timedelta(minutes=1), id="minute"),
+        pytest.param(0, 0, 0, 0, 0, 1, timedelta(seconds=1), id="second"),
         pytest.param(
-            1, 2, 3, 4, timedelta(days=1, hours=2, minutes=3, seconds=4), id="all"
+            1, 2, 3, 4, 5, 6, timedelta(days=365 + 60 + 3, hours=4, minutes=5, seconds=6), id="all"
         ),
     ],
 )
-def test_total_time(days, hours, minutes, seconds, expected):
-    config = get_driver_config(days=days, hours=hours, minutes=minutes, seconds=seconds)
+def test_total_time(years, months, days, hours, minutes, seconds, expected):
+    config = get_driver_config(
+        years=years, months=months, days=days, hours=hours, minutes=minutes, seconds=seconds
+    )
     assert config.total_time == expected
 
 


### PR DESCRIPTION
… (fixes #197)

**Description**
Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes # (issue)
If this is a hotfix to a released version, please specify it.

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
*********** *********************** ***************
This PR adds `years` and `months` attributes to `DriverConfig` to support longer simulation runtimes without requiring manual unit conversion to total days/weeks.

- Added `years` (365 days/yr) and `months` (30 days/mo) to `DriverConfig`
- Updated `total_time` property calculation
- Added parameterized test cases in `tests/main/driver/test_driver.py`

Fixes #197