### PR TITLE
build: pace has no py-3.13 support due to pySHiELD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,14 @@ classifiers = [
   "Intended Audience :: Developers",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13"
+  "Programming Language :: Python :: 3.12"
 ]
 dynamic = ["dependencies"]
 license = "Apache-2.0"
 license-files = ["LICENSE.md"]
 name = "pace"
 readme = "README.md"
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.13"
 version = "0.2.0"
 
 [project.optional-dependencies]
@@ -38,7 +37,7 @@ Repository = "https://github.com/NOAA-GFDL/pace"
 [tool.aliases]
 
 [tool.black]
-target-version = ["py312", "py313"]
+target-version = ["py312"]
 
 [tool.bumpversion]
 commit = "True"


### PR DESCRIPTION
**Description**

`pace` depends on `pySHiELD`. `pySHiELD` depends on a homegrown version of `pyrte-rrtmgp`. That `pyrte-rrtmgp` only supports python versions 3.11 and 3.12. Since `NDSL` only supports 3.12 and 3.13, we end up with `pace` only supporting 3.12.

The good news here is that the official version of `pyrte-rrtmgp` supports python versions 3.13 and 3.14. Once the "upstream" changes are merged into the "NOAA version" of `pyrte-rrtmgp`, we can support 3.13 and possibly 3.14 in both pySHiELD and pace.

**How Has This Been Tested?**

Trying a local install with 3.14 in the context of https://github.com/NOAA-GFDL/NDSL/pull/554.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
